### PR TITLE
Add Apache-2.0 license headers and LLM attribution to switchmap_py modules

### DIFF
--- a/switchmap_py/__init__.py
+++ b/switchmap_py/__init__.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 """Switchmap Python reimplementation."""
 
 __all__ = ["__version__"]

--- a/switchmap_py/cli.py
+++ b/switchmap_py/cli.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -94,7 +106,9 @@ def get_arp(
                 continue
             mac, ip, *rest = [part.strip() for part in line.split(",")]
             hostname = rest[0] if rest else None
-            entries.append(MacEntry(mac=mac, ip=ip, hostname=hostname, switch=None, port=None))
+            entries.append(
+                MacEntry(mac=mac, ip=ip, hostname=hostname, switch=None, port=None)
+            )
     else:
         raise typer.BadParameter("Only csv source is supported in this implementation")
     store.save(entries)

--- a/switchmap_py/config.py
+++ b/switchmap_py/config.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/switchmap_py/model/__init__.py
+++ b/switchmap_py/model/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+

--- a/switchmap_py/model/arp.py
+++ b/switchmap_py/model/arp.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/switchmap_py/model/mac.py
+++ b/switchmap_py/model/mac.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/switchmap_py/model/port.py
+++ b/switchmap_py/model/port.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/switchmap_py/model/switch.py
+++ b/switchmap_py/model/switch.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/switchmap_py/model/vlan.py
+++ b/switchmap_py/model/vlan.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/switchmap_py/render/__init__.py
+++ b/switchmap_py/render/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+

--- a/switchmap_py/render/build.py
+++ b/switchmap_py/render/build.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import asdict

--- a/switchmap_py/search/__init__.py
+++ b/switchmap_py/search/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+

--- a/switchmap_py/search/app.py
+++ b/switchmap_py/search/app.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 import http.server

--- a/switchmap_py/search/index_builder.py
+++ b/switchmap_py/search/index_builder.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 import json

--- a/switchmap_py/snmp/__init__.py
+++ b/switchmap_py/snmp/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+

--- a/switchmap_py/snmp/collectors.py
+++ b/switchmap_py/snmp/collectors.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -34,9 +46,7 @@ def _normalize_status(value: str) -> str:
     return {"1": "up", "2": "down"}.get(value, value)
 
 
-def collect_switch_state(
-    switch: SwitchConfig, timeout: int, retries: int
-) -> Switch:
+def collect_switch_state(switch: SwitchConfig, timeout: int, retries: int) -> Switch:
     session = build_session(switch, timeout, retries)
     names = session.get_table(mibs.IF_NAME)
     descrs = session.get_table(mibs.IF_DESCR)
@@ -48,7 +58,9 @@ def collect_switch_state(
     for oid, name in names.items():
         index = oid.split(".")[-1]
         descr = descrs.get(f"{mibs.IF_DESCR}.{index}", "")
-        admin_status = _normalize_status(admin.get(f"{mibs.IF_ADMIN_STATUS}.{index}", ""))
+        admin_status = _normalize_status(
+            admin.get(f"{mibs.IF_ADMIN_STATUS}.{index}", "")
+        )
         oper_status = _normalize_status(oper.get(f"{mibs.IF_OPER_STATUS}.{index}", ""))
         speed = speeds.get(f"{mibs.IF_SPEED}.{index}")
         ports.append(

--- a/switchmap_py/snmp/mibs.py
+++ b/switchmap_py/snmp/mibs.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 IF_NAME = "1.3.6.1.2.1.31.1.1.1.1"
 IF_DESCR = "1.3.6.1.2.1.2.2.1.2"
 IF_ADMIN_STATUS = "1.3.6.1.2.1.2.2.1.7"

--- a/switchmap_py/snmp/session.py
+++ b/switchmap_py/snmp/session.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -41,7 +53,7 @@ class SnmpSession:
             raise SnmpError("SNMP community not configured")
 
         results: dict[str, str] = {}
-        for (error_indication, error_status, error_index, var_binds) in nextCmd(
+        for error_indication, error_status, error_index, var_binds in nextCmd(
             SnmpEngine(),
             CommunityData(self.config.community),
             UdpTransportTarget(

--- a/switchmap_py/storage/__init__.py
+++ b/switchmap_py/storage/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+

--- a/switchmap_py/storage/idlesince_store.py
+++ b/switchmap_py/storage/idlesince_store.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -47,8 +59,12 @@ class IdleSinceStore:
     def save(self, switch_name: str, data: dict[str, PortIdleState]) -> None:
         payload = {
             port: {
-                "idle_since": state.idle_since.isoformat() if state.idle_since else None,
-                "last_active": state.last_active.isoformat() if state.last_active else None,
+                "idle_since": state.idle_since.isoformat()
+                if state.idle_since
+                else None,
+                "last_active": state.last_active.isoformat()
+                if state.last_active
+                else None,
             }
             for port, state in data.items()
         }

--- a/switchmap_py/storage/maclist_store.py
+++ b/switchmap_py/storage/maclist_store.py
@@ -1,3 +1,15 @@
+# Copyright 2024
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
 from __future__ import annotations
 
 import json

--- a/tests/test_idlesince_store.py
+++ b/tests/test_idlesince_store.py
@@ -24,7 +24,9 @@ def test_idle_transition(tmp_path):
     assert updated.idle_since == ts
     assert updated.last_active is None
 
-    updated_active = store.update_port(updated, port=state.port, is_active=True, observed_at=ts)
+    updated_active = store.update_port(
+        updated, port=state.port, is_active=True, observed_at=ts
+    )
     assert updated_active.idle_since is None
     assert updated_active.last_active == ts
 
@@ -47,7 +49,9 @@ def test_save_load_roundtrip(tmp_path):
 
     data = {
         "Gi1/0/3": PortIdleState(port="Gi1/0/3", idle_since=idle_ts, last_active=None),
-        "Gi1/0/4": PortIdleState(port="Gi1/0/4", idle_since=None, last_active=active_ts),
+        "Gi1/0/4": PortIdleState(
+            port="Gi1/0/4", idle_since=None, last_active=active_ts
+        ),
     }
 
     store.save("switch-1", data)


### PR DESCRIPTION
### Motivation
- Ensure every Python source under `switchmap_py/` contains the project license header, `SPDX-License-Identifier: Apache-2.0`, and an LLM attribution header per repository policy.
- Make header text consistent with existing test files to avoid header-style drift across the codebase.
- Satisfy repository pre-PR requirements for LLM-generated changes by adding explicit license and attribution text to modified files.

### Description
- Prepend the recommended Apache-2.0 license header plus the LLM attribution line to the Python modules under `switchmap_py/` (22 modules changed) and one test file to match existing test headers. 
- Minor formatting adjustments were applied to keep code style consistent (line breaks in function arguments/structures where appropriate). 
- Files modified by the LLM: `switchmap_py/__init__.py`, `switchmap_py/cli.py`, `switchmap_py/config.py`, `switchmap_py/model/__init__.py`, `switchmap_py/model/arp.py`, `switchmap_py/model/mac.py`, `switchmap_py/model/port.py`, `switchmap_py/model/switch.py`, `switchmap_py/model/vlan.py`, `switchmap_py/render/__init__.py`, `switchmap_py/render/build.py`, `switchmap_py/search/__init__.py`, `switchmap_py/search/app.py`, `switchmap_py/search/index_builder.py`, `switchmap_py/snmp/__init__.py`, `switchmap_py/snmp/collectors.py`, `switchmap_py/snmp/mibs.py`, `switchmap_py/snmp/session.py`, `switchmap_py/storage/__init__.py`, `switchmap_py/storage/idlesince_store.py`, `switchmap_py/storage/maclist_store.py`, and `tests/test_idlesince_store.py`. 
- Human review: automated checks were run but no manual code review has been performed beyond those checks.

### Testing
- Ran `python -m pytest` and received `7 passed` indicating unit tests succeeded. 
- Ran `python -m ruff check switchmap_py tests` and `python -m ruff format --check switchmap_py tests` (followed by `python -m ruff format switchmap_py tests` to apply formatting) and the linter/formatter checks passed. 
- Ran `python -m mypy switchmap_py` which failed due to missing type stubs for PyYAML (`types-PyYAML`); installation was blocked by network proxy errors so type checking remains outstanding. 
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in the environment, so pre-commit hooks were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646e63b8308330b0c2c513966623d5)