### PR TITLE
Restrict SNMP configuration to v2c and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SNMP collection, idle port tracking, static HTML generation, and a lightweight s
 ## Requirements
 
 - Python 3.12+
-- SNMP access to network devices (for `scan-switch` / `build-html`)
+- SNMP v2c access to network devices (for `scan-switch` / `build-html`)
 - Optional dependencies for SNMP and search features
 
 ## Installation
@@ -46,13 +46,13 @@ switches:
   - name: core-sw1
     management_ip: 192.0.2.10
     vendor: cisco
-    snmp_version: 2c
+    snmp_version: 2c  # v2c only
     community: public
     trunk_ports: ["Gi1/0/48"]
 routers:
   - name: edge-router
     management_ip: 192.0.2.1
-    snmp_version: 2c
+    snmp_version: 2c  # v2c only
     community: public
 ```
 
@@ -90,7 +90,7 @@ SNMP収集、アイドルポートの追跡、静的HTML生成、軽量な検索
 ## 動作要件
 
 - Python 3.12以上
-- ネットワーク機器へのSNMPアクセス（`scan-switch` / `build-html`で使用）
+- ネットワーク機器へのSNMP v2cアクセス（`scan-switch` / `build-html`で使用）
 - SNMPや検索機能のためのオプション依存関係
 
 ## インストール
@@ -123,13 +123,13 @@ switches:
   - name: core-sw1
     management_ip: 192.0.2.10
     vendor: cisco
-    snmp_version: 2c
+    snmp_version: 2c  # v2cのみ
     community: public
     trunk_ports: ["Gi1/0/48"]
 routers:
   - name: edge-router
     management_ip: 192.0.2.1
-    snmp_version: 2c
+    snmp_version: 2c  # v2cのみ
     community: public
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@ pip install -e .[snmp,search]
 ## Configuration
 
 Create `site.yml` in the repository root (or pass `--config`).
+SNMP v2c is the only supported version.
 
 ```yaml
 destination_directory: output
@@ -29,13 +30,13 @@ switches:
   - name: core-sw1
     management_ip: 192.0.2.10
     vendor: cisco
-    snmp_version: 2c
+    snmp_version: 2c  # v2c only
     community: public
     trunk_ports: ["Gi1/0/48"]
 routers:
   - name: edge-router
     management_ip: 192.0.2.1
-    snmp_version: 2c
+    snmp_version: 2c  # v2c only
     community: public
 ```
 

--- a/switchmap_py/config.py
+++ b/switchmap_py/config.py
@@ -1,3 +1,14 @@
+# Copyright 2025 Switchmapy
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 from __future__ import annotations
 
 from pathlib import Path
@@ -12,18 +23,15 @@ class SwitchConfig(BaseModel):
     name: str
     management_ip: str
     vendor: str = "generic"
-    snmp_version: Literal["2c", "3"] = "2c"
+    snmp_version: Literal["2c"] = "2c"
     community: Optional[str] = None
-    username: Optional[str] = None
-    auth_key: Optional[str] = None
-    priv_key: Optional[str] = None
     trunk_ports: list[str] = Field(default_factory=list)
 
 
 class RouterConfig(BaseModel):
     name: str
     management_ip: str
-    snmp_version: Literal["2c", "3"] = "2c"
+    snmp_version: Literal["2c"] = "2c"
     community: Optional[str] = None
 
 


### PR DESCRIPTION
### Motivation

- The SNMP session implementation currently only supports SNMP v2c, so configuration should not advertise v3 support.
- Allowing `snmp_version: "3"` in the config is misleading and can cause runtime errors when SNMP v3 is not implemented.
- Ensure source files modified by the change include a license header and LLM attribution to satisfy repository policy.

### Description

- Restrict `snmp_version` to `"2c"` in `SwitchConfig` and `RouterConfig` by changing the type to `Literal["2c"]` and removing unused v3 credential fields in `switchmap_py/config.py`.
- Add an Apache-2.0 license header and an LLM-attribution notice to `switchmap_py/config.py`.
- Clarify SNMP v2c-only requirements and add inline comments to the example `site.yml` in `README.md` and `docs/usage.md`.
- LLM involvement: modified files `switchmap_py/config.py`, `README.md`, and `docs/usage.md`; automated tests were run locally but manual human review of the code and security is still recommended.

### Testing

- Ran unit tests with `pytest` and all tests passed (`7 passed`).
- Test command executed: `pytest`.
- No repository linter/formatter was configured or run as part of this change.
- CI was not re-run locally; CI should validate the branch after push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646e6aa2248330bf6d1bfa8f3ed3e8)