### PR TITLE
Use textContent to render search results (avoid innerHTML)

### DIFF
--- a/switchmap_py/render/templates/search.html.j2
+++ b/switchmap_py/render/templates/search.html.j2
@@ -1,3 +1,16 @@
+<!--
+Copyright 2025 SwitchMapy Contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
 <!doctype html>
 <html lang="en">
 <head>
@@ -38,16 +51,21 @@
 
     function render(entries) {
       const tbody = document.getElementById('results');
-      tbody.innerHTML = '';
+      tbody.replaceChildren();
       for (const entry of entries) {
         const row = document.createElement('tr');
-        row.innerHTML = `
-          <td>${entry.mac ?? ''}</td>
-          <td>${entry.ip ?? ''}</td>
-          <td>${entry.hostname ?? ''}</td>
-          <td>${entry.switch ?? ''}</td>
-          <td>${entry.port ?? ''}</td>
-        `;
+        const values = [
+          entry.mac ?? '',
+          entry.ip ?? '',
+          entry.hostname ?? '',
+          entry.switch ?? '',
+          entry.port ?? '',
+        ];
+        for (const value of values) {
+          const cell = document.createElement('td');
+          cell.textContent = value;
+          row.appendChild(cell);
+        }
         tbody.appendChild(row);
       }
     }


### PR DESCRIPTION
### Motivation
- Prevent HTML injection in the search UI by avoiding `innerHTML` when rendering table cells.
- Preserve existing search/filter behavior while making rendering safer.
- Add a license header and explicit LLM attribution to the template file to satisfy project policy.
- Keep changes minimal and limited to the static search template.

### Description
- Replace row construction via `row.innerHTML = ...` with per-cell `document.createElement('td')` and `cell.textContent` to ensure values are rendered as text.
- Use `tbody.replaceChildren()` instead of assigning `innerHTML = ''` to clear results before rendering.
- Add a license comment block with `SPDX-License-Identifier: Apache-2.0` and an AI attribution header to `switchmap_py/render/templates/search.html.j2`.
- Files modified by the LLM: `switchmap_py/render/templates/search.html.j2`, and human review focused on DOM creation and injection safety.

### Testing
- Ran unit tests with `python -m pytest` which completed successfully: `7 passed` in `0.52s`.
- No additional automated test failures were observed when running the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646e7d261c833090fea1656d044829)