### PR TITLE
Log OID fetch failures for SNMP collectors

### DIFF
--- a/tests/test_collectors_logging.py
+++ b/tests/test_collectors_logging.py
@@ -1,0 +1,49 @@
+# Copyright 2025 OpenAI Codex
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+import logging
+
+from switchmap_py.snmp import collectors, mibs
+
+
+class FakeSession:
+    def __init__(self, failures: set[str]) -> None:
+        self.failures = failures
+
+    def get_table(self, oid: str) -> dict[str, str]:
+        if oid in self.failures:
+            raise RuntimeError("boom")
+        if oid == mibs.DOT1D_BASE_PORT_IFINDEX:
+            return {f"{mibs.DOT1D_BASE_PORT_IFINDEX}.1": "10"}
+        return {}
+
+
+def test_bridge_port_map_logs_warning_on_exception(caplog):
+    session = FakeSession({mibs.DOT1D_BASE_PORT_IFINDEX})
+
+    with caplog.at_level(logging.WARNING):
+        result = collectors._bridge_port_map(session)
+
+    assert result == {}
+    assert any(
+        mibs.DOT1D_BASE_PORT_IFINDEX in record.message for record in caplog.records
+    )
+
+
+def test_collect_macs_logs_warning_on_exception(caplog):
+    session = FakeSession({mibs.QBRIDGE_VLAN_FDB_PORT})
+
+    with caplog.at_level(logging.WARNING):
+        result = collectors._collect_macs(session)
+
+    assert result == {}
+    assert any(mibs.QBRIDGE_VLAN_FDB_PORT in record.message for record in caplog.records)


### PR DESCRIPTION
### Motivation
- Improve observability by recording which SNMP OID fetch fails so debugging is easier.
- Avoid silent failures in the MAC/bridge-port collection paths (`_bridge_port_map` and `_collect_macs`).

### Description
- Add a module logger by defining `logger = logging.getLogger(__name__)` in `switchmap_py/snmp/collectors.py`.
- Emit `logger.warning(...)` with the failing OID and `exc_info=True` inside `except Exception` handlers for SNMP table fetches of `DOT1D_BASE_PORT_IFINDEX`, `QBRIDGE_VLAN_FDB_PORT`, `QBRIDGE_VLAN_FDB_STATUS`, `DOT1D_TP_FDB_PORT`, and `DOT1D_TP_FDB_STATUS`.
- Add `tests/test_collectors_logging.py` which uses a fake session to raise exceptions and asserts warning logs include the failed OID.
- LLM-modified files: `switchmap_py/snmp/collectors.py` and `tests/test_collectors_logging.py`, and human review: not yet performed.

### Testing
- Validation command run: `pytest`.
- Test results: all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647a24f07c83308387324968540814)