### PR TITLE
Skip invalid maclist records and log warnings

### DIFF
--- a/switchmap_py/storage/maclist_store.py
+++ b/switchmap_py/storage/maclist_store.py
@@ -13,9 +13,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from switchmap_py.model.mac import MacEntry
+
+logger = logging.getLogger(__name__)
 
 
 class MacListStore:
@@ -26,7 +29,20 @@ class MacListStore:
         if not self.path.exists():
             return []
         payload = json.loads(self.path.read_text())
-        return [MacEntry(**entry) for entry in payload]
+        entries: list[MacEntry] = []
+        skipped: list[str] = []
+        for index, entry in enumerate(payload):
+            try:
+                entries.append(MacEntry(**entry))
+            except (TypeError, ValueError) as exc:
+                skipped.append(f"{index}: {exc}")
+        if skipped:
+            logger.warning(
+                "Skipped %d invalid maclist record(s): %s",
+                len(skipped),
+                "; ".join(skipped),
+            )
+        return entries
 
     def save(self, entries: list[MacEntry]) -> None:
         payload = [entry.__dict__ for entry in entries]


### PR DESCRIPTION
### Motivation
- Prevent crashes when the maclist file contains malformed or unexpected records by continuing to load valid entries.
- Surface actionable diagnostics by reporting how many records were skipped and why via logging.

### Description
- Update `MacListStore.load` to parse entries in a loop and `try/except` each record, appending valid `MacEntry` objects and skipping invalid ones.
- Accumulate skip reasons and emit a warning via `logger.warning` with the skipped count and reasons when any records are skipped.
- Add `tests/test_maclist_store.py::test_load_skips_invalid_records` to verify mixed valid/invalid payloads load without crashing and that a warning is emitted.
- Files modified by the LLM: `switchmap_py/storage/maclist_store.py`, `tests/test_maclist_store.py`, and human review: not yet performed.

### Testing
- Run tests with `python -m pytest` which executed the test suite and all tests passed (`9 passed`).
- The new test `test_load_skips_invalid_records` asserts valid entries are returned and the warning contains `"Skipped 2 invalid maclist record(s)"`.
- Validation command used: `python -m pytest`.
- No lint/format/static-analysis commands were configured or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647a34fdac8330bf05a6b4312220da)