### PR TITLE
Add IF_NAME fallback for SNMP port naming and test

### DIFF
--- a/switchmap_py/snmp/collectors.py
+++ b/switchmap_py/snmp/collectors.py
@@ -50,6 +50,15 @@ def _format_mac(parts: list[str]) -> str:
     return ":".join(f"{int(part):02x}" for part in parts)
 
 
+def _select_port_name(if_name: str, if_descr: str, ifindex: int | None) -> str:
+    # Priority: IF_NAME (if non-empty) → IF_DESCR → ifIndex as a last resort.
+    if if_name:
+        return if_name
+    if if_descr:
+        return if_descr
+    return str(ifindex) if ifindex is not None else ""
+
+
 def _parse_mac_from_oid(oid: str, prefix: str, *, vlan_aware: bool) -> tuple[str, str | None] | None:
     prefix_parts = prefix.split(".")
     oid_parts = oid.split(".")
@@ -169,13 +178,18 @@ def collect_switch_state(
         index = oid.split(".")[-1]
         ifindex = int(index) if index.isdigit() else None
         descr = descrs.get(f"{mibs.IF_DESCR}.{index}", "")
+        resolved_name = _select_port_name(
+            (name or "").strip(),
+            (descr or "").strip(),
+            ifindex,
+        )
         admin_status = _normalize_status(
             admin.get(f"{mibs.IF_ADMIN_STATUS}.{index}", "")
         )
         oper_status = _normalize_status(oper.get(f"{mibs.IF_OPER_STATUS}.{index}", ""))
         speed = speeds.get(f"{mibs.IF_SPEED}.{index}")
         port = Port(
-            name=name,
+            name=resolved_name,
             descr=descr,
             admin_status=admin_status,
             oper_status=oper_status,
@@ -184,7 +198,7 @@ def collect_switch_state(
             macs=[],
             idle_since=None,
             last_active=None,
-            is_trunk=name in switch.trunk_ports,
+            is_trunk=resolved_name in switch.trunk_ports,
         )
         ports.append(port)
         if ifindex is not None:

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,65 @@
+# Copyright 2025 OpenAI Codex
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from switchmap_py.config import SwitchConfig
+from switchmap_py.snmp import collectors, mibs
+
+
+class StubSession:
+    def __init__(self, tables):
+        self._tables = tables
+
+    def get_table(self, oid):
+        return self._tables.get(oid, {})
+
+
+def test_collect_switch_state_falls_back_to_descr_or_ifindex(monkeypatch):
+    switch = SwitchConfig(
+        name="sw1",
+        management_ip="192.0.2.1",
+        community="public",
+        trunk_ports=["Gi1/0/1"],
+    )
+    tables = {
+        mibs.IF_NAME: {
+            f"{mibs.IF_NAME}.1": "",
+            f"{mibs.IF_NAME}.2": "",
+        },
+        mibs.IF_DESCR: {
+            f"{mibs.IF_DESCR}.1": "Gi1/0/1",
+            f"{mibs.IF_DESCR}.2": "",
+        },
+        mibs.IF_ADMIN_STATUS: {
+            f"{mibs.IF_ADMIN_STATUS}.1": "1",
+            f"{mibs.IF_ADMIN_STATUS}.2": "1",
+        },
+        mibs.IF_OPER_STATUS: {
+            f"{mibs.IF_OPER_STATUS}.1": "1",
+            f"{mibs.IF_OPER_STATUS}.2": "2",
+        },
+        mibs.IF_SPEED: {
+            f"{mibs.IF_SPEED}.1": "1000",
+            f"{mibs.IF_SPEED}.2": "1000",
+        },
+    }
+
+    monkeypatch.setattr(
+        collectors,
+        "build_session",
+        lambda *_args, **_kwargs: StubSession(tables),
+    )
+    monkeypatch.setattr(collectors, "_collect_macs", lambda _session: {})
+
+    state = collectors.collect_switch_state(switch, timeout=1, retries=0)
+    assert state.ports[0].name == "Gi1/0/1"
+    assert state.ports[0].is_trunk is True
+    assert state.ports[1].name == "2"


### PR DESCRIPTION
### Motivation
- The SNMP `IF_NAME` table can be empty on some devices, resulting in unnamed ports and incorrect trunk detection.
- Provide a deterministic fallback to ensure ports always have a usable name for downstream logic.
- Make the preferred selection order explicit and documented in code so future maintainers understand the behavior.

### Description
- Add `_select_port_name` which returns `IF_NAME` if non-empty, otherwise `IF_DESCR`, otherwise the `ifIndex` string, and document the priority in a code comment.
- Use the resolved name when constructing `Port` objects and when checking `switch.trunk_ports` so trunk detection works with fallbacks.
- Add `tests/test_collectors.py` which stubs SNMP tables to verify behavior when `IF_NAME` entries are empty.
- Modified files: `switchmap_py/snmp/collectors.py`, `tests/test_collectors.py` (this change was created or modified with the assistance of an AI; please review for correctness and security).

### Testing
- Ran the unit test command `pytest tests/test_collectors.py`.
- Test results: `1 passed` for the added test.
- No linting or formatting commands were run in this environment.
- Static analysis/type checks were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647a36ae8c83308a531ed54d7bebcc)