### PR TITLE
[codex] Add FortiSwitch collection diagnostics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ PR content and quality expectations
 - Validation commands: list exact commands used to validate lint, tests, and formatting.
 - Attach logs or screenshots if the change affects UI or developer UX.
 - Commit messages: follow the repository's convention (e.g., Conventional Commits). Keep commits atomic and well-scoped.
+- Public PRs and repository files must describe only repository code, product behavior, public fixtures, and reproducible commands. Do not include local validation environment details such as private lab names, controller URLs, private IP allocations, node inventories, local workspace paths, temporary artifact directories, or operational notes from a contributor's private lab. Keep that information only in private/local notes outside Git tracking.
 
 PR checklist (include in PR description or use as template)
 - [ ] License header added to new files and top-level LICENSE present

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -23,6 +23,7 @@ Review required for correctness, security, and licensing.
 - [コマンド](commands.ja.md)
 - [テスト](testing.ja.md)
 - [移行メモ](migration_notes.ja.md)
+- [SwitchMap 差分分析](switchmap_gap_analysis.ja.md)
 
 ## 方針
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Review required for correctness, security, and licensing.
 - [Commands](commands.md)
 - [Testing](testing.md)
 - [Migration Notes](migration_notes.md)
+- [SwitchMap Gap Analysis](switchmap_gap_analysis.md)
 
 ## Scope
 

--- a/docs/migration_notes.ja.md
+++ b/docs/migration_notes.ja.md
@@ -38,6 +38,8 @@ Review required for correctness, security, and licensing.
 
 ## Perl SwitchMap との差分として残るもの
 
+詳細な一覧は [SwitchMap 差分分析](switchmap_gap_analysis.ja.md) を参照してください。
+
 - 従来HTMLレイアウトの完全一致は保証しません。
 - 長年運用された Perl 版に比べ、機種別OID対応の幅はまだ狭い可能性があります。
 - `ThisSite.pm` の公開・定期実行などのサイト固有処理は、Perl互換ランタイムではなく

--- a/docs/migration_notes.md
+++ b/docs/migration_notes.md
@@ -38,6 +38,8 @@ Review required for correctness, security, and licensing.
 
 ## Remaining Differences from Perl SwitchMap
 
+See [SwitchMap Gap Analysis](switchmap_gap_analysis.md) for the full matrix.
+
 - Exact legacy HTML layout parity is not guaranteed.
 - Device-family OID coverage may still be narrower than mature Perl deployments.
 - Site-specific `ThisSite.pm` behaviors such as publishing and scheduling are

--- a/docs/switchmap_gap_analysis.ja.md
+++ b/docs/switchmap_gap_analysis.ja.md
@@ -1,0 +1,60 @@
+<!--
+Copyright 2026 switchmappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# SwitchMap 差分分析
+
+- English version: [switchmap_gap_analysis.md](switchmap_gap_analysis.md)
+
+このページは、Perl 版 SwitchMap ツール群である `SwitchMap.pl`、`ScanSwitch.pl`、
+`GetArp.pl`、`FindOffice.pl`、`SearchPortlists.html`、およびサイト固有の
+`ThisSite.pm` ロジックと switchmappy を比較します。
+
+## ステータス
+
+- `Implemented`: switchmappy で対応済み。
+- `Partial`: 対応済みだが既知の制限あり。
+- `Not yet`: 未実装。
+- `Intentionally different`: 意図的に異なる設計。
+
+## 機能差分表
+
+| 領域 | ステータス | switchmappy の対応 | 残作業 |
+| --- | --- | --- | --- |
+| 静的 switch map 生成 | Implemented | `switchmap build-html` が index、switch、ports、VLAN、endpoint、search、history、debug を生成。 | 従来HTMLレイアウト完全一致は明示要求がない限り目標にしない。 |
+| idle-since tracking | Implemented | `scan-switch` がスイッチ単位の idle state を更新。 | vendor追加時にfixtureを拡張。 |
+| ARP import | Implemented | CSV と SNMP router ARP import をサポート。 | 必要に応じてrouter-family fixtureを追加。 |
+| MAC/IP/hostname 相関 | Implemented | MAC list、ARP data、hostname import、reverse DNS、OUI表示に対応。 | SSH endpoint 相関は再現可能な fixture と integration test で維持する。 |
+| Search UI | Implemented | `search/index.json` ベースの静的検索ページと FastAPI serve command。 | office/location workflow は専用viewが必要。 |
+| SSH switch collection | Implemented | Cisco系、Juniper、FortiSwitch、Arista向け command profile。 | platform variant のfixture拡張。 |
+| SNMP switch collection | Partial | IF-MIB、BRIDGE-MIB fallback、VLAN名、LLDP、sysDescr、sysUpTime。 | device-family OID と VLAN-aware FDB 検証を拡張。 |
+| VLAN-aware SNMP FDB | Partial | デバイスが公開する場合は Q-BRIDGE FDB をparse。SNMP communityとして設定すれば VLAN-indexed community 収集も動作。 | VLAN-aware FDB を公開する device family の再現可能な fixture を追加する。 |
+| LLDP/CDP neighbors | Implemented | SSH LLDP/CDP と SNMP LLDP neighbor を表示。 | vendor固有出力のcapability fixtureを追加。 |
+| Neighbor capabilities | Partial | CDP capability と SNMP LLDP capability bitmap を保持。 | capability field を省略または変化させる device fixture を追加する。 |
+| Trunk/uplink 表示 | Intentionally different | role は明示 `trunk_ports` または LLDP/CDP neighbor 根拠で決定。 | MAC数やendpoint数をrole根拠に使わない。 |
+| Operational switchport evidence | Implemented | Cisco系SSHで mode、access VLAN、voice VLAN、native VLAN、allowed VLANs を取得。 | 非Cisco系の同等情報を追加。 |
+| Switch inventory | Partial | SSH `show version` と SNMP `sysDescr`/`sysUpTime` を表示。 | platform別のmodel/serial/version OIDを追加。 |
+| PoE/error counters | Partial | 対応profileでSSH PoE status/power と input/output errors を表示。 | SNMP PoE/error OID とfixtureを拡張。 |
+| History/diffs | Implemented | history snapshot と差分ページを生成。 | 出力増加時はretention制御を検討。 |
+| Debug diagnostics | Implemented | correlation trace、unmatched data、anomaly、artifact、port evidence を表示。 | Q-BRIDGE unavailable などSNMP FDB診断ラベルを追加。 |
+| Site configuration | Intentionally different | `ThisSite.pm` は YAML 設定に置き換え。 | 公開・定期実行は外部automationで扱う。 |
+| Office/location workflows | Not yet | 現在のsearchは host/IP/MAC/switch/port を対象。 | location/office metadata import とviewを追加。 |
+| Perl module互換 | Intentionally different | Python modules は collection、rendering、storage、search に分割。 | Perl APIの直接互換は予定しない。 |
+
+## 高優先度の残作業
+
+1. Debug payload/UI に SNMP FDB 診断を追加する。
+2. office/location metadata import と location-oriented view を追加する。
+3. VLAN-aware SNMP FDB fixture を追加VLANへ拡張する、または Q-BRIDGE 対応ターゲットを追加する。
+4. 代表的なCisco platform向けの structured inventory OID を追加する。
+5. SSH command parsing 以外の PoE/error counter coverage を拡張する。

--- a/docs/switchmap_gap_analysis.md
+++ b/docs/switchmap_gap_analysis.md
@@ -1,0 +1,60 @@
+<!--
+Copyright 2026 switchmappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# SwitchMap Gap Analysis
+
+- Japanese translation: [switchmap_gap_analysis.ja.md](switchmap_gap_analysis.ja.md)
+
+This page compares switchmappy with the original Perl SwitchMap tool family as
+used by `SwitchMap.pl`, `ScanSwitch.pl`, `GetArp.pl`, `FindOffice.pl`,
+`SearchPortlists.html`, and site-specific `ThisSite.pm` logic.
+
+## Status Legend
+
+- `Implemented`: supported by switchmappy.
+- `Partial`: supported with known scope limits.
+- `Not yet`: not implemented.
+- `Intentionally different`: switchmappy deliberately uses a different design.
+
+## Capability Matrix
+
+| Area | Status | switchmappy Support | Remaining Work |
+| --- | --- | --- | --- |
+| Static switch map generation | Implemented | `switchmap build-html` renders index, switch, ports, VLAN, endpoint, search, history, and debug pages. | Legacy HTML layout parity is not a goal unless explicitly required. |
+| Idle-since tracking | Implemented | `scan-switch` updates per-switch idle state. | Broaden device fixtures if more vendors are added. |
+| ARP import | Implemented | CSV and SNMP router ARP import are supported. | Add more router-family fixtures if needed. |
+| MAC/IP/hostname correlation | Implemented | MAC list, ARP data, hostname import, reverse DNS, and OUI display are supported. | Keep SSH endpoint correlation covered by repeatable fixtures and integration tests. |
+| Search UI | Implemented | Static search page backed by `search/index.json`; FastAPI serve command exists. | Office/location workflows need a dedicated view. |
+| SSH switch collection | Implemented | Cisco-like, Juniper, FortiSwitch, and Arista-oriented command profiles exist. | Expand command fixtures for more platform variants. |
+| SNMP switch collection | Partial | IF-MIB, BRIDGE-MIB fallback, VLAN names, LLDP, sysDescr, and sysUpTime are supported. | Add richer device-family OID support and VLAN-aware FDB validation on non-IOL-L2 labs. |
+| VLAN-aware SNMP FDB | Partial | Q-BRIDGE FDB is parsed when devices expose it; VLAN-indexed community collection works when configured as the SNMP community. | Add repeatable fixtures for device families that expose VLAN-aware FDB data. |
+| LLDP/CDP neighbors | Implemented | SSH LLDP/CDP and SNMP LLDP neighbors are rendered. | Add more capability fixtures for vendor-specific outputs. |
+| Neighbor capabilities | Partial | CDP capabilities and SNMP LLDP capability bitmaps are retained when available. | Add fixtures for devices that omit or vary capability fields. |
+| Trunk/uplink display | Intentionally different | Roles use explicit `trunk_ports` or LLDP/CDP neighbor evidence. | Do not use MAC count or endpoint count as role evidence. |
+| Operational switchport evidence | Implemented | Cisco-like SSH captures mode, access VLAN, voice VLAN, native VLAN, and allowed VLANs. | Add non-Cisco equivalents where available. |
+| Switch inventory | Partial | SSH `show version` and SNMP `sysDescr`/`sysUpTime` are rendered. | Add structured model/serial/version OIDs per platform. |
+| PoE and error counters | Partial | SSH collectors expose PoE status/power and input/output errors for supported profiles. | Add SNMP PoE/error OIDs and more device fixtures. |
+| History and diffs | Implemented | History snapshots and diff pages are generated. | Consider retention controls if output grows. |
+| Debug diagnostics | Implemented | Debug page shows correlation traces, unmatched data, anomalies, artifacts, and port evidence. | Add SNMP FDB diagnostic labels such as Q-BRIDGE unavailable. |
+| Site configuration | Intentionally different | YAML replaces `ThisSite.pm`. | Publishing/scheduling remains external automation. |
+| Office/location workflows | Not yet | Current search covers host/IP/MAC/switch/port. | Add location/office metadata import and views. |
+| Exact Perl module compatibility | Intentionally different | Python modules split collection, rendering, storage, and search. | No direct Perl API compatibility planned. |
+
+## Highest-Value Remaining Work
+
+1. Add SNMP FDB diagnostics to the debug payload and UI.
+2. Add office/location metadata import and a location-oriented view.
+3. Expand VLAN-aware SNMP FDB fixtures to additional VLANs or add a Q-BRIDGE-capable target.
+4. Add structured inventory OIDs for common Cisco platforms.
+5. Expand PoE/error counter coverage beyond SSH command parsing.

--- a/docs/testing.ja.md
+++ b/docs/testing.ja.md
@@ -16,7 +16,7 @@ Review required for correctness, security, and licensing.
 
 - English version: [testing.md](testing.md)
 
-## ローカル標準検証
+## 標準検証
 
 ```bash
 python -m ruff check .
@@ -36,3 +36,13 @@ python -m pre_commit run --all-files
 ## 回帰メモ
 
 - XSS 回帰シナリオは `tests/XSS_REGRESSION_TESTS.md` に記載。
+## Mixed-Vendor 回帰検証
+
+mixed-vendor behavior は unit fixture と integration-ready な site 設定で
+検証します。FortiSwitch trunk 検証は 2 段階に分かれます:
+
+- 設定意図: `trunk_ports` で既知の uplink を明示し、endpoint や MAC 数に
+  依存せず trunk/uplink として表示されること。
+- デバイス報告の証跡: FortiSwitch の physical port と VLAN membership 出力から
+  access VLAN、port mode、allowed VLAN fields を埋めること。trunk/uplink
+  状態は、見えているホスト MAC 数から推測してはいけません。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,3 +36,13 @@ python -m pre_commit run --all-files
 ## Regression Notes
 
 - XSS regression scenarios are documented in `tests/XSS_REGRESSION_TESTS.md`.
+## Mixed-Vendor Regression
+
+Mixed-vendor behavior is covered by unit fixtures and integration-ready site
+configuration. FortiSwitch trunk validation has two levels:
+
+- Configured intent: `trunk_ports` marks known uplinks explicitly and should
+  render as trunk/uplink without relying on endpoint or MAC counts.
+- Device-reported evidence: FortiSwitch physical port and VLAN membership output
+  should populate access VLAN, port mode, and allowed VLAN fields. Trunk/uplink
+  status must not be inferred from the number of visible host MAC addresses.

--- a/switchmap_py/render/build.py
+++ b/switchmap_py/render/build.py
@@ -225,6 +225,8 @@ def _build_debug_payload(
     switch_macs = {mac.lower() for port in ports for mac in port.macs}
     correlated_keys = {str(row.get("mac", "")).lower() for row in endpoint_rows}
     maclist_keys = {entry.mac.lower() for entry in maclist if entry.mac}
+    artifacts = _build_artifact_summary(artifacts_dir)
+    artifact_diagnostics = _build_artifact_diagnostics(artifacts)
     unmatched_maclist = [
         {
             **asdict(entry),
@@ -300,11 +302,19 @@ def _build_debug_payload(
     switch_debug = []
     for switch in switches:
         switch_ports = switch.ports
+        diagnostics = artifact_diagnostics.get(switch.name, {})
         switch_debug.append(
             {
                 "name": switch.name,
                 "management_ip": switch.management_ip,
                 "vendor": switch.vendor,
+                "parser_profile": _parser_profile_for_vendor(switch.vendor),
+                "collection_methods": ", ".join(diagnostics.get("methods", [])),
+                "artifact_count": diagnostics.get("artifact_count", 0),
+                "successful_artifacts": diagnostics.get("successful_artifacts", 0),
+                "error_artifacts": diagnostics.get("error_artifacts", 0),
+                "unsupported_artifacts": diagnostics.get("unsupported_artifacts", 0),
+                "commands": ", ".join(diagnostics.get("commands", [])),
                 "platform": switch.platform,
                 "serial_number": switch.serial_number,
                 "os_version": switch.os_version,
@@ -341,8 +351,61 @@ def _build_debug_payload(
         "unmatched_maclist": unmatched_maclist,
         "unmatched_switch_macs": unmatched_switch_macs,
         "anomalies": anomalies,
-        "artifacts": _build_artifact_summary(artifacts_dir),
+        "artifacts": artifacts,
     }
+
+
+def _parser_profile_for_vendor(vendor: str) -> str:
+    value = vendor.lower()
+    if "juniper" in value:
+        return "juniper"
+    if "fortinet" in value or "fortiswitch" in value:
+        return "fortiswitch"
+    if "arista" in value:
+        return "arista"
+    return "cisco_like"
+
+
+def _build_artifact_diagnostics(artifacts: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    diagnostics: dict[str, dict[str, object]] = {}
+    for artifact in artifacts:
+        switch_name = str(artifact.get("switch") or "")
+        if not switch_name:
+            continue
+        record = diagnostics.setdefault(
+            switch_name,
+            {
+                "methods": set(),
+                "commands": [],
+                "artifact_count": 0,
+                "successful_artifacts": 0,
+                "error_artifacts": 0,
+                "unsupported_artifacts": 0,
+            },
+        )
+        record["artifact_count"] += 1
+        method = str(artifact.get("method") or "")
+        if method:
+            record["methods"].add(method)
+        name = str(artifact.get("name") or "")
+        if name:
+            record["commands"].append(name)
+        status = str(artifact.get("status") or "").lower()
+        if status == "success":
+            record["successful_artifacts"] += 1
+        elif status == "error":
+            record["error_artifacts"] += 1
+        text = " ".join(str(artifact.get(key) or "").lower() for key in ("status", "name", "relative_path"))
+        if "unsupported" in text or "no such" in text or "invalid" in text or "parse error" in text:
+            record["unsupported_artifacts"] += 1
+    normalized = {}
+    for switch_name, record in diagnostics.items():
+        normalized[switch_name] = {
+            **record,
+            "methods": sorted(record["methods"]),
+            "commands": sorted(set(record["commands"])),
+        }
+    return normalized
 
 
 def _build_artifact_summary(artifacts_dir: Path | None) -> list[dict[str, object]]:

--- a/switchmap_py/render/templates/debug.html.j2
+++ b/switchmap_py/render/templates/debug.html.j2
@@ -126,6 +126,12 @@ Review required for correctness, security, and licensing.
             <th>Switch</th>
             <th>Management IP</th>
             <th>Vendor</th>
+            <th>Profile</th>
+            <th>Methods</th>
+            <th>Artifacts</th>
+            <th>OK</th>
+            <th>Errors</th>
+            <th>Unsupported</th>
             <th>Platform</th>
             <th>Version</th>
             <th>Serial</th>
@@ -144,6 +150,12 @@ Review required for correctness, security, and licensing.
             <td>{{ switch.name }}</td>
             <td>{{ switch.management_ip }}</td>
             <td>{{ switch.vendor }}</td>
+            <td>{{ switch.parser_profile }}</td>
+            <td>{{ switch.collection_methods }}</td>
+            <td>{{ switch.artifact_count }}</td>
+            <td>{{ switch.successful_artifacts }}</td>
+            <td>{{ switch.error_artifacts }}</td>
+            <td>{{ switch.unsupported_artifacts }}</td>
             <td>{{ switch.platform }}</td>
             <td>{{ switch.os_version }}</td>
             <td>{{ switch.serial_number }}</td>

--- a/switchmap_py/ssh/collectors.py
+++ b/switchmap_py/ssh/collectors.py
@@ -114,7 +114,7 @@ def _normalize_oper_status(status: str) -> str:
 
 
 def _parse_speed(token: str) -> int | None:
-    match = re.search(r"(\d+)$", token)
+    match = re.search(r"(\d+)", token)
     if not match:
         return None
     try:
@@ -248,13 +248,27 @@ def _parse_fortiswitch_interface_status(text: str, switch: SwitchConfig) -> list
         if len(tokens) < 2:
             continue
         name = tokens[0]
-        if not re.match(r"^(port|internal)\d+", name.lower()):
+        if not re.match(r"^(?:port\d+|internal\d*)$", name.lower()):
             continue
         raw_status = tokens[1]
+        vlan = None
+        speed_token = tokens[2] if len(tokens) > 2 else ""
+        descr_start = 3
+        switchport_mode = None
+        access_vlan = None
+        if len(tokens) >= 6 and re.fullmatch(r"[0-9a-fA-F]{4}", tokens[2]) and _VLAN_ID_RE.match(tokens[3]):
+            vlan = tokens[3]
+            access_vlan = vlan
+            speed_token = tokens[5]
+            descr_start = 7
+            flag_tokens = {token.strip(" ,").upper() for token in tokens[6:] if token.strip(" ,")}
+            switchport_mode = "trunk" if flag_tokens & {"QS", "QE", "QI", "TS", "TF", "TL"} else "access"
         oper_status = _normalize_oper_status(raw_status)
         admin_status = "down" if oper_status == "down" else "up"
-        speed = _parse_speed(tokens[2]) if len(tokens) > 2 else None
-        descr = " ".join(tokens[3:]) if len(tokens) > 3 else ""
+        speed = _parse_speed(speed_token) if speed_token and speed_token != "-" else None
+        descr = " ".join(tokens[descr_start:]) if len(tokens) > descr_start else ""
+        if descr.replace(" ", "") in {",,none", ",none", "none"}:
+            descr = ""
         ports.append(
             Port(
                 name=name,
@@ -262,8 +276,10 @@ def _parse_fortiswitch_interface_status(text: str, switch: SwitchConfig) -> list
                 admin_status=admin_status,
                 oper_status=oper_status,
                 speed=speed,
-                vlan=None,
+                vlan=vlan,
                 macs=[],
+                switchport_mode=switchport_mode,
+                access_vlan=access_vlan,
                 is_trunk=_is_trunk_port(name, switch),
             )
         )
@@ -323,7 +339,15 @@ def _parse_fortiswitch_mac_table(text: str) -> dict[str, set[str]]:
         if not line:
             continue
         lower = line.lower()
-        if lower.startswith(("vlan", "mac", "----")):
+        if lower.startswith(("vlan", "----")) or lower.startswith("mac address"):
+            continue
+        if lower.startswith("mac:"):
+            mac_match = re.search(r"\bMAC:\s+([0-9a-fA-F:.-]{12,17})", line, flags=re.IGNORECASE)
+            port_match = re.search(r"\bPort:\s+([^\s(]+)", line, flags=re.IGNORECASE)
+            canonical = _canonical_port_name(port_match.group(1)) if port_match else ""
+            normalized_mac = _normalize_mac(mac_match.group(1) if mac_match else "")
+            if canonical and normalized_mac:
+                macs_by_port.setdefault(canonical, set()).add(normalized_mac)
             continue
         tokens = _WS_RE.split(line)
         if len(tokens) < 3:
@@ -387,6 +411,7 @@ def _parse_juniper_vlans(text: str) -> dict[str, str]:
 
 def _parse_fortiswitch_vlans(text: str) -> dict[str, str]:
     vlan_by_port: dict[str, str] = {}
+    vlans_by_port: dict[str, list[str]] = {}
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line:
@@ -400,11 +425,16 @@ def _parse_fortiswitch_vlans(text: str) -> dict[str, str]:
             continue
         for token in tokens:
             for candidate in token.split(","):
-                if not re.match(r"^(port|internal)\d+", candidate.lower()):
+                if not re.match(r"^(?:port\d+|internal\d*)$", candidate.lower()):
                     continue
                 canonical = _canonical_port_name(candidate)
                 if canonical:
                     vlan_by_port[canonical] = vlan_id
+                    vlans_by_port.setdefault(canonical, []).append(vlan_id)
+    for canonical, vlan_ids in vlans_by_port.items():
+        unique_vlan_ids = sorted(set(vlan_ids), key=lambda vlan_id: int(vlan_id))
+        if len(unique_vlan_ids) > 1:
+            vlan_by_port[canonical] = ",".join(unique_vlan_ids)
     return vlan_by_port
 
 
@@ -452,6 +482,7 @@ def _is_rejected_command_output(output: str) -> bool:
     return (
         "% invalid input detected" in lowered
         or "% invalid command" in lowered
+        or "command parse error" in lowered
         or "line has invalid autocommand" in lowered
     )
 
@@ -562,6 +593,40 @@ def _parse_cisco_lldp_neighbors_detail(text: str) -> dict[str, list[Neighbor]]:
     return neighbors_by_port
 
 
+def _parse_fortiswitch_lldp_neighbors_detail(text: str) -> dict[str, list[Neighbor]]:
+    neighbors_by_port: dict[str, list[Neighbor]] = {}
+    current_local: str | None = None
+    current_neighbor: str | None = None
+    current_remote_port: str | None = None
+
+    def flush_current() -> None:
+        nonlocal current_local, current_neighbor, current_remote_port
+        if current_local and current_neighbor:
+            _add_neighbor(neighbors_by_port, current_local, current_neighbor, "lldp", remote_port=current_remote_port)
+        current_local = None
+        current_neighbor = None
+        current_remote_port = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        lower = line.lower()
+        if lower.startswith("neighbor learned on port"):
+            flush_current()
+            match = re.search(r"\bport\s+(\S+)\s+by\s+lldp", line, flags=re.IGNORECASE)
+            current_local = _canonical_port_name(match.group(1)) if match else None
+            continue
+        if lower.startswith("system name:"):
+            current_neighbor = line.split(":", 1)[1].strip()
+            continue
+        if lower.startswith("port id:"):
+            current_remote_port = line.split(":", 1)[1].strip().split(None, 1)[0]
+            continue
+    flush_current()
+    return neighbors_by_port
+
+
 def _parse_capabilities(value: str) -> list[str]:
     tokens = [token.strip(" ,") for token in re.split(r"[\s,]+", value) if token.strip(" ,")]
     ignored = {"capabilities", "enabled", "system", "bridge:"}
@@ -643,6 +708,27 @@ def _parse_cisco_show_version(text: str) -> SwitchInventory:
             inventory.serial_number = line.split(":", 1)[1].strip() if ":" in line else line.split()[-1]
         elif not inventory.serial_number and lower.startswith("processor board id"):
             inventory.serial_number = line.split()[-1]
+    return inventory
+
+
+def _parse_fortiswitch_system_status(text: str) -> SwitchInventory:
+    inventory = SwitchInventory()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if "# " in line:
+            line = line.rsplit("# ", 1)[1].strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "version":
+            inventory.os_version = value
+            platform_match = re.match(r"([^,\s]+)", value)
+            if platform_match:
+                inventory.platform = platform_match.group(1)
+        elif key == "serial-number":
+            inventory.serial_number = value
     return inventory
 
 
@@ -863,7 +949,7 @@ def _collect_interface_output(session: SshSession, switch: SwitchConfig, timeout
     if profile == "juniper":
         command = "show interfaces terse"
     elif profile == "fortiswitch":
-        command = "get switch interface status"
+        command = "diagnose switch physical-ports summary"
     else:
         command = "show interfaces status"
     return _run_command(session, command, timeout=timeout, retries=_PRIMARY_COMMAND_RETRIES)
@@ -874,7 +960,7 @@ def _collect_mac_output(session: SshSession, switch: SwitchConfig, timeout: int)
     if profile == "juniper":
         command = "show ethernet-switching table"
     elif profile == "fortiswitch":
-        command = "get switch mac-address-table"
+        command = "diagnose switch mac-address list"
     else:
         command = "show mac address-table"
     return _run_command(session, command, timeout=timeout)
@@ -885,7 +971,7 @@ def _collect_vlan_output(session: SshSession, switch: SwitchConfig, timeout: int
     if profile == "juniper":
         command = "show vlans"
     elif profile == "fortiswitch":
-        command = "show switch vlan"
+        command = "diagnose switch vlan list"
     else:
         command = "show vlan brief"
     return _run_command(session, command, timeout=timeout)
@@ -897,7 +983,7 @@ def _collect_neighbors(session: SshSession, switch: SwitchConfig, timeout: int) 
         return _parse_neighbor_table(_run_command(session, "show lldp neighbors", timeout=timeout), "lldp")
     if profile == "fortiswitch":
         output = _run_command(session, "get switch lldp neighbors-detail", timeout=timeout)
-        return _parse_neighbor_table(output, "lldp")
+        return _parse_fortiswitch_lldp_neighbors_detail(output) or _parse_neighbor_table(output, "lldp")
 
     lldp_neighbors: dict[str, list[Neighbor]] = {}
     try:
@@ -952,10 +1038,13 @@ def _collect_switchport_details(session: SshSession, switch: SwitchConfig, timeo
 
 def _collect_inventory(session: SshSession, switch: SwitchConfig, timeout: int) -> SwitchInventory:
     profile = _vendor_profile(switch.vendor)
-    if profile not in {"cisco_like", "arista"}:
-        return SwitchInventory()
-    output = _run_command(session, "show version", timeout=timeout)
-    return _parse_cisco_show_version(output)
+    if profile == "fortiswitch":
+        output = _run_command(session, "get system status", timeout=timeout)
+        return _parse_fortiswitch_system_status(output)
+    if profile in {"cisco_like", "arista"}:
+        output = _run_command(session, "show version", timeout=timeout)
+        return _parse_cisco_show_version(output)
+    return SwitchInventory()
 
 
 def collect_switch_state(switch: SwitchConfig, timeout: int, artifact_dir: Path | None = None) -> Switch:
@@ -999,12 +1088,14 @@ def collect_switch_state(switch: SwitchConfig, timeout: int, artifact_dir: Path 
             else:
                 vlan_by_port = _parse_cisco_vlan_brief(vlan_output)
             for port in ports:
-                if port.vlan:
-                    continue
                 canonical = _canonical_port_name(port.name)
                 mapped_vlan = vlan_by_port.get(canonical)
+                if profile == "fortiswitch" and mapped_vlan and "," in mapped_vlan:
+                    port.allowed_vlans = mapped_vlan
+                if port.vlan:
+                    continue
                 if mapped_vlan:
-                    port.vlan = mapped_vlan
+                    port.vlan = mapped_vlan.split(",", maxsplit=1)[0]
         except SshError:
             logger.warning(
                 "SSH VLAN collection command failed for switch %s; continuing without VLAN table.",
@@ -1054,12 +1145,18 @@ def collect_switch_state(switch: SwitchConfig, timeout: int, artifact_dir: Path 
                     continue
                 port.input_errors = counters[0]
                 port.output_errors = counters[1]
-        except SshError:
-            logger.warning(
-                "SSH error counter collection command failed for switch %s; continuing without counters.",
-                switch.name,
-                exc_info=True,
-            )
+        except SshError as exc:
+            if _is_unsupported_optional_command(exc):
+                logger.debug(
+                    "SSH error counter collection command is unsupported on switch %s; continuing without counters.",
+                    switch.name,
+                )
+            else:
+                logger.warning(
+                    "SSH error counter collection command failed for switch %s; continuing without counters.",
+                    switch.name,
+                    exc_info=True,
+                )
         try:
             poe_by_port = _collect_poe_status(session, switch, timeout=timeout)
             for port in ports:

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -241,7 +241,16 @@ def test_build_site_renders_debug_page_and_payload(tmp_path):
                     "status": "success",
                     "relative_path": "sw1/ssh-command-show_interfaces_status.txt",
                     "bytes": 42,
-                }
+                },
+                {
+                    "switch": "sw1",
+                    "method": "ssh",
+                    "kind": "ssh-command",
+                    "name": "show unsupported",
+                    "status": "error",
+                    "relative_path": "sw1/ssh-command-show_unsupported.txt",
+                    "bytes": 12,
+                },
             ]
         ),
         encoding="utf-8",
@@ -293,7 +302,14 @@ def test_build_site_renders_debug_page_and_payload(tmp_path):
     assert debug["build"]["failed_switch_reasons"] == {"sw-bad": "[SNMP_ERROR] timeout"}
     assert debug["correlation_trace"][0]["source"] == "maclist + switch mac table"
     assert debug["artifacts"][0]["name"] == "show interfaces status"
+    assert debug["switches"][0]["parser_profile"] == "cisco_like"
+    assert debug["switches"][0]["collection_methods"] == "ssh"
+    assert debug["switches"][0]["artifact_count"] == 2
+    assert debug["switches"][0]["successful_artifacts"] == 1
+    assert debug["switches"][0]["error_artifacts"] == 1
+    assert debug["switches"][0]["unsupported_artifacts"] == 1
     assert "Collector Artifacts" in debug_html
+    assert "Unsupported" in debug_html
     assert 'id="debugRole"' in debug_html
 
 

--- a/tests/test_ssh_collectors.py
+++ b/tests/test_ssh_collectors.py
@@ -447,37 +447,46 @@ def test_collect_switch_state_uses_fortiswitch_command(monkeypatch):
     )
     status_output = "\n".join(
         [
-            "Port Status Speed Description",
-            "port1 up 1000 Uplink-Core",
-            "port2 down 100 User-Edge",
+            "Portname Status Tpid Vlan Duplex Speed Flags Discard",
+            "port1 up 8100 10 full 1000M , , none",
+            "port2 down 8100 10 full 100M , , none",
         ]
     )
     session = StubSession(
         by_command={
-            "get switch interface status": status_output,
-            "get switch mac-address-table": "10 00:11:22:33:44:77 dynamic port1",
-            "show switch vlan": "default 10 port1,port2",
+            "diagnose switch physical-ports summary": status_output,
+            "diagnose switch mac-address list": "MAC: 00:11:22:33:44:77\tVLAN: 10 Port: port1(port-id 1)",
+            "diagnose switch vlan list": "10 port1 port2",
             "get switch lldp neighbors-detail": "port1 aa:bb:cc:dd:ee:ff port48 fsw-core-1",
             "diagnose switch physical-ports error-counters": "port1 2 3\nport2 0 1",
             "get switch poe inline-status": "port1 Enabled Delivering 8.8W\nport2 Enabled Off 0.0W",
+            "get system status": "\n".join(
+                [
+                    "fortiswitch-edge # Version: FortiSwitch-108D-VM v7.2.0,build4746,220621 (Interim)",
+                    "Serial-Number: S108DVIUL-MKIA2D",
+                ]
+            ),
         }
     )
     monkeypatch.setattr(collectors, "build_session", lambda *_args, **_kwargs: session)
 
     state = collectors.collect_switch_state(switch, timeout=3)
     assert session.commands == [
-        "get switch interface status",
-        "get switch mac-address-table",
-        "show switch vlan",
+        "diagnose switch physical-ports summary",
+        "diagnose switch mac-address list",
+        "diagnose switch vlan list",
         "get switch lldp neighbors-detail",
         "diagnose switch physical-ports error-counters",
         "get switch poe inline-status",
+        "get system status",
     ]
     assert [port.name for port in state.ports] == ["port1", "port2"]
     assert state.ports[0].oper_status == "up"
     assert state.ports[0].speed == 1000
     assert state.ports[0].macs == ["00:11:22:33:44:77"]
     assert state.ports[0].vlan == "10"
+    assert state.ports[0].switchport_mode == "access"
+    assert state.ports[0].access_vlan == "10"
     assert _neighbor_devices(state.ports[0]) == ["fsw-core-1"]
     assert _neighbor_protocols(state.ports[0]) == ["lldp"]
     assert state.ports[0].input_errors == 2
@@ -486,10 +495,91 @@ def test_collect_switch_state_uses_fortiswitch_command(monkeypatch):
     assert state.ports[0].poe_power_w == 8.8
     assert state.ports[1].oper_status == "down"
     assert state.ports[1].vlan == "10"
+    assert state.ports[1].switchport_mode == "access"
+    assert state.ports[1].access_vlan == "10"
     assert state.ports[1].input_errors == 0
     assert state.ports[1].output_errors == 1
     assert state.ports[1].poe_status == "off"
     assert state.ports[1].poe_power_w == 0.0
+    assert state.platform == "FortiSwitch-108D-VM"
+    assert state.os_version == "FortiSwitch-108D-VM v7.2.0,build4746,220621 (Interim)"
+    assert state.serial_number == "S108DVIUL-MKIA2D"
+
+
+def test_collect_switch_state_parses_cml_fortiswitch_vm_output(monkeypatch):
+    switch = SwitchConfig(
+        name="sw-forti",
+        management_ip="192.0.2.80",
+        vendor="fortiswitch",
+        collection_method="ssh",
+        ssh_username="ops",
+        ssh_password="pw",
+        trunk_ports=["port1"],
+    )
+    session = StubSession(
+        by_command={
+            "diagnose switch physical-ports summary": "\n".join(
+                [
+                    "  Portname    Status  Tpid  Vlan  Duplex  Speed  Flags         Discard",
+                    "  __________  ______  ____  ____  ______  _____  ____________  _________",
+                    "  port1       up      8100  1     full    100M   QS,  ,        none",
+                    "  port2       down    8100  1     full    -        ,  ,        none",
+                    "  internal    up      8100  1     full    100M     ,  ,        none",
+                ]
+            ),
+            "diagnose switch mac-address list": "\n".join(
+                [
+                    "MAC: 52:54:00:00:10:10\tVLAN: 1 Port: port1(port-id 1)",
+                    "  Flags: 0x13000000 [ dynamic age forward-dst forward-src ]",
+                    "MAC: 36:f0:e1:7f:00:01\tVLAN: 1 Port: internal(port-id 9)",
+                ]
+            ),
+            "diagnose switch vlan list": "\n".join(
+                [
+                    "  VlanId  Ports",
+                    "  ______  ___________________________________________________",
+                    "  1       port1 port2 port3 port4 port5 port6 port7 port8 internal",
+                    "  10      port1",
+                ]
+            ),
+            "get switch lldp neighbors-detail": "\n".join(
+                [
+                    "Neighbor learned on port port1 by LLDP protocol",
+                    "System Name: edge-sw3.switchmappy.local",
+                    "Port ID: Et0/3 (ifname)",
+                ]
+            ),
+            "diagnose switch physical-ports error-counters": "command parse error before 'error-counters'",
+            "get switch poe inline-status": "command parse error before 'inline-status'",
+            "get system status": "\n".join(
+                [
+                    "Version: FortiSwitch-108D-VM v7.2.0,build4746,220621 (Interim)",
+                    "Serial-Number: S108DVIUL-MKIA2D",
+                ]
+            ),
+        }
+    )
+    monkeypatch.setattr(collectors, "build_session", lambda *_args, **_kwargs: session)
+
+    state = collectors.collect_switch_state(switch, timeout=3)
+
+    assert [port.name for port in state.ports] == ["port1", "port2", "internal"]
+    assert state.ports[0].oper_status == "up"
+    assert state.ports[0].speed == 100
+    assert state.ports[0].descr == ""
+    assert state.ports[0].vlan == "1"
+    assert state.ports[0].switchport_mode == "trunk"
+    assert state.ports[0].access_vlan == "1"
+    assert state.ports[0].allowed_vlans == "1,10"
+    assert state.ports[0].macs == ["52:54:00:00:10:10"]
+    assert state.ports[0].is_trunk is True
+    assert _neighbor_devices(state.ports[0]) == ["edge-sw3.switchmappy.local"]
+    assert _neighbor_protocols(state.ports[0]) == ["lldp"]
+    assert state.ports[1].oper_status == "down"
+    assert state.ports[2].macs == ["36:f0:e1:7f:00:01"]
+    assert state.platform == "FortiSwitch-108D-VM"
+    assert state.os_version == "FortiSwitch-108D-VM v7.2.0,build4746,220621 (Interim)"
+    assert state.serial_number == "S108DVIUL-MKIA2D"
 
 
 def test_collect_switch_state_falls_back_to_cdp_neighbors(monkeypatch):


### PR DESCRIPTION
## Summary

- Add FortiSwitch SSH collection support for inventory, MAC, LLDP, VLAN, port mode, and allowed VLAN membership.
- Enrich the debug page with parser profile and collector artifact diagnostics.
- Add public documentation for SwitchMap feature parity, migration notes, testing expectations, and mixed-vendor behavior.
- Add a contributor rule that public PRs and repository files must not include private validation environment details.

## Rationale

This moves SwitchMappy closer to the original SwitchMap-style operational view by improving non-Cisco collection and exposing parser/collector evidence in the generated debug page. FortiSwitch support uses device-reported physical port and VLAN membership data rather than MAC-count based trunk inference.

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q` (`142 passed, 1 skipped`)
- `.venv/bin/pre-commit run --all-files`

## LLM Involvement

Files created/modified with AI assistance:

- `.github/copilot-instructions.md`
- `docs/README.md`
- `docs/README.ja.md`
- `docs/migration_notes.md`
- `docs/migration_notes.ja.md`
- `docs/switchmap_gap_analysis.md`
- `docs/switchmap_gap_analysis.ja.md`
- `docs/testing.md`
- `docs/testing.ja.md`
- `switchmap_py/oui.py`
- `switchmap_py/render/build.py`
- `switchmap_py/render/templates/debug.html.j2`
- `switchmap_py/ssh/collectors.py`
- `tests/test_build_site.py`
- `tests/test_oui.py`
- `tests/test_ssh_collectors.py`

Human review required for correctness, security, and licensing before merge.

## Checklist

- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: 10/10 (command: `.venv/bin/ruff check .`)
- [x] Tests pass locally (command: `.venv/bin/python -m pytest -q`)
- [x] Static analysis/type checks pass (command: `.venv/bin/ruff check .`)
- [x] Formatting applied (command: `.venv/bin/ruff format --check .`)
- [x] Pre-commit hooks pass
- [ ] CI build passes
- [x] No merge conflicts with base branch at PR creation time
- [x] Changelog/versioning updated (not applicable)
- [x] Documentation updated
- [x] Examples/quick-start updated (not applicable)
- [x] Commit messages follow repository conventions
- [x] PR description includes summary, rationale, tests, docs, and migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
