### PR TITLE
Publish onboarding docs with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+# Copyright 2026 switchmappy
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+name: Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ pip install -e .[dev]
 
 ## Documentation
 
-- [Onboarding Documentation UI](docs/index.html)
+- [Onboarding Documentation UI](https://icecake0141.github.io/switchmappy/) (GitHub Pages)
 - [Quick Start and User Tour](docs/onboarding.md)
 - [Configuration Reference](docs/configuration.md)
 - [Command Reference](docs/commands.md)
 - [Testing](docs/testing.md)
+- [GitHub Pages publishing notes](docs/pages.md)
 
 ### English
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -18,8 +18,9 @@ Review required for correctness, security, and licensing.
 
 ## セクション
 
-- [オンボーディングドキュメントUI](index.html)
+- [オンボーディングドキュメントUI](https://icecake0141.github.io/switchmappy/) (GitHub Pages)
 - [クイックスタートとユーザツアー](onboarding.ja.md)
+- [GitHub Pages ドキュメント](pages.ja.md)
 - [仕様](specification.ja.md)
 - [設定](configuration.ja.md)
 - [コマンド](commands.ja.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,9 @@ Review required for correctness, security, and licensing.
 
 ## Sections
 
-- [Onboarding Documentation UI](index.html)
+- [Onboarding Documentation UI](https://icecake0141.github.io/switchmappy/) (GitHub Pages)
 - [Quick Start and User Tour](onboarding.md)
+- [GitHub Pages Documentation](pages.md)
 - [Specification](specification.md)
 - [Configuration](configuration.md)
 - [Commands](commands.md)

--- a/docs/onboarding.ja.md
+++ b/docs/onboarding.ja.md
@@ -15,7 +15,8 @@ Review required for correctness, security, and licensing.
 # クイックスタートとユーザツアー
 
 - English original: [onboarding.md](onboarding.md)
-- 静的な英日UI: [index.html](index.html)
+- 静的な英日UI: <https://icecake0141.github.io/switchmappy/>
+- 公開手順: [GitHub Pages ドキュメント](pages.ja.md)
 
 ## クイックスタート
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -15,7 +15,8 @@ Review required for correctness, security, and licensing.
 # Quick Start and User Tour
 
 - Japanese translation: [onboarding.ja.md](onboarding.ja.md)
-- Static bilingual UI: [index.html](index.html)
+- Static bilingual UI: <https://icecake0141.github.io/switchmappy/>
+- Publishing notes: [GitHub Pages Documentation](pages.md)
 
 ## Quick Start
 

--- a/docs/pages.ja.md
+++ b/docs/pages.ja.md
@@ -1,0 +1,45 @@
+<!--
+Copyright 2026 switchmappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# GitHub Pages ドキュメント
+
+- English original: [pages.md](pages.md)
+
+オンボーディングUIは静的HTMLです。GitHubリポジトリの通常ファイル表示では
+HTMLソースとして表示されるため、言語トグル付きUIはGitHub Pagesで公開します。
+
+- 公開UI: <https://icecake0141.github.io/switchmappy/>
+- GitHub上で読めるfallback: [クイックスタートとユーザツアー](onboarding.ja.md)
+
+## 公開方式
+
+`Pages` workflow が `main` の `docs/` ディレクトリを公開します。
+
+必要なリポジトリ設定:
+
+- Settings -> Pages -> Build and deployment -> Source: `GitHub Actions`
+
+workflow完了後、`docs/index.html` がPagesのトップページとして公開されます。
+Markdownページは、GitHub上で直接読む利用者やPagesを有効化していないfork向けに
+残します。
+
+## ローカルプレビュー
+
+同じディレクトリをローカルでプレビューできます。
+
+```bash
+python -m http.server 8767
+```
+
+その後、`http://127.0.0.1:8767/docs/` を開きます。

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,45 @@
+<!--
+Copyright 2026 switchmappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# GitHub Pages Documentation
+
+- Japanese translation: [pages.ja.md](pages.ja.md)
+
+The onboarding UI is a static HTML page. GitHub repository file browsing shows
+the HTML source, so use GitHub Pages for the interactive language toggle:
+
+- Published UI: <https://icecake0141.github.io/switchmappy/>
+- GitHub-readable fallback: [Quick Start and User Tour](onboarding.md)
+
+## Publishing Model
+
+The `Pages` workflow publishes the `docs/` directory from `main`.
+
+Required repository setting:
+
+- Settings -> Pages -> Build and deployment -> Source: `GitHub Actions`
+
+After the workflow completes, `docs/index.html` is available as the Pages
+homepage. The Markdown pages remain available in the repository for users who
+read docs directly on GitHub or in forks that do not enable Pages.
+
+## Local Preview
+
+Preview the same directory locally:
+
+```bash
+python -m http.server 8767
+```
+
+Then open `http://127.0.0.1:8767/docs/`.


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that publishes the `docs/` directory from `main`
- update README and docs indexes so the interactive onboarding UI points to the Pages URL
- add English and Japanese Pages publishing notes while keeping Markdown onboarding pages as GitHub-readable fallbacks

## Rationale
GitHub repository file browsing shows `docs/index.html` as source instead of running the language toggle UI. Publishing `docs/` with GitHub Pages makes the static onboarding experience directly usable while preserving Markdown docs for repository browsing and forks.

## Validation commands
- `python scripts/check_docs_links.py`
- `pre-commit run --all-files`
- Local preview: `python -m http.server 8767 --bind 127.0.0.1`, then verified `/docs/`, onboarding screenshots, and `pages.md`/`pages.ja.md` were reachable over HTTP

## Docs updated
- `README.md`
- `docs/README.md`
- `docs/README.ja.md`
- `docs/onboarding.md`
- `docs/onboarding.ja.md`
- `docs/pages.md`
- `docs/pages.ja.md`

## LLM involvement
Files created or modified with LLM assistance in this PR include: `.github/workflows/pages.yml`, `README.md`, `docs/README.md`, `docs/README.ja.md`, `docs/onboarding.md`, `docs/onboarding.ja.md`, `docs/pages.md`, and `docs/pages.ja.md`.

Human review required for correctness, security, and licensing before merge.

## Compatibility and migration notes
- No Python API or CLI behavior changes.
- Repository Pages is enabled with `build_type=workflow`; the Pages workflow in this PR will publish `docs/` after merge.

## Checklist
- [x] License header added to new text/source files and top-level LICENSE present
- [x] LLM attribution added to modified/generated text/source files
- [x] Linting/format hooks completed (command: `pre-commit run --all-files`)
- [x] Documentation links pass (command: `python scripts/check_docs_links.py`)
- [x] Documentation updated (README, docs/)
- [x] PR description includes summary, rationale, validation, docs, and migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes
- [ ] CI/Pages build passes
- [x] Repository Pages setting confirmed as `GitHub Actions`