### PR TITLE
Acknowledge the original Switchmap project

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ status, correlate ARP/MAC data, review VLANs, and serve a local search UI.
 English documentation is primary. Japanese onboarding content is available from
 the static documentation UI.
 
+## Acknowledgement
+
+switchmappy is based on Pete Siemsen's original
+[Switchmap](https://switchmap.sourceforge.net/). Although the original UI is
+classical and the project is no longer actively updated, it remains a precise,
+thoughtfully built, and fully functional tool. Many engineers have tried to
+bring similar switch-port mapping workflows forward in Ruby, Python, and other
+modern stacks. This project is one such attempt to revive that great original
+for contemporary environments.
+
 ## Quick Start
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -306,6 +306,9 @@ Review required for correctness, security, and licensing.
       </div>
 
       <h2 id="en-quick-start">Quick Start</h2>
+      <h3>Before You Begin</h3>
+      <p>switchmappy is based on Pete Siemsen's original <a href="https://switchmap.sourceforge.net/">Switchmap</a>. The original Switchmap has a classic web UI and is no longer actively updated, but it remains a precise, complete, and fully functional tool. Many engineers have tried to carry the same idea forward in Ruby, Python, and other modern implementations. switchmappy is one more attempt to bring that great original back into active use for today's network operations.</p>
+
       <pre><code>python -m venv .venv
 source .venv/bin/activate
 pip install -e .[snmp,search]
@@ -388,6 +391,9 @@ switches:
       </div>
 
       <h2 id="ja-quick-start">クイックスタート</h2>
+      <h3>初めに</h3>
+      <p>switchmappy は Pete Siemsen 氏によるオリジナル版 <a href="https://switchmap.sourceforge.net/">Switchmap</a> を元にしています。オリジナルのSwitchmapは、UIこそクラシカルで現在は活発に更新されていないものの、今でも非常に精巧で、完成度が高く、完全に機能するツールです。これまで多くの先人たちが、Ruby、Python、その他の現代的な実装で同じようなスイッチポートマッピングの仕組みを作ろうとしてきました。switchmappy もまた、その偉大なオリジナルを現代のネットワーク運用環境に甦らせようとする試みの一つです。</p>
+
       <pre><code>python -m venv .venv
 source .venv/bin/activate
 pip install -e .[snmp,search]

--- a/docs/onboarding.ja.md
+++ b/docs/onboarding.ja.md
@@ -18,6 +18,16 @@ Review required for correctness, security, and licensing.
 - 静的な英日UI: <https://icecake0141.github.io/switchmappy/>
 - 公開手順: [GitHub Pages ドキュメント](pages.ja.md)
 
+## 初めに
+
+switchmappy は Pete Siemsen 氏によるオリジナル版
+[Switchmap](https://switchmap.sourceforge.net/) を元にしています。
+オリジナルのSwitchmapは、UIこそクラシカルで現在は活発に更新されていないものの、
+今でも非常に精巧で、完成度が高く、完全に機能するツールです。これまで多くの
+先人たちが、Ruby、Python、その他の現代的な実装で同じようなスイッチポート
+マッピングの仕組みを作ろうとしてきました。switchmappy もまた、その偉大な
+オリジナルを現代のネットワーク運用環境に甦らせようとする試みの一つです。
+
 ## クイックスタート
 
 SNMPと検索UIの依存関係を含めてインストールします。

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -18,6 +18,16 @@ Review required for correctness, security, and licensing.
 - Static bilingual UI: <https://icecake0141.github.io/switchmappy/>
 - Publishing notes: [GitHub Pages Documentation](pages.md)
 
+## Before You Begin
+
+switchmappy is based on Pete Siemsen's original
+[Switchmap](https://switchmap.sourceforge.net/). The original Switchmap has a
+classic web UI and is no longer actively updated, but it is still a remarkably
+complete and functional tool. Many people have tried to carry the same idea
+forward in Ruby, Python, and other modern implementations. switchmappy is one
+more attempt to bring that great original back into active use for today's
+network operations.
+
 ## Quick Start
 
 Install switchmappy with SNMP and search support:


### PR DESCRIPTION
## Summary
- add an acknowledgement of Pete Siemsen's original Switchmap to the README
- add matching English and Japanese "Before You Begin" / "初めに" sections to onboarding docs
- add the same acknowledgement to the static bilingual onboarding UI

## Rationale
switchmappy is based on the original Switchmap project. The docs should make that lineage explicit, link back to the original, and frame this project as a modern revival rather than an unrelated implementation.

## Validation commands
- `python scripts/check_docs_links.py`
- `pre-commit run --all-files`
- Local preview: `python -m http.server 8767 --bind 127.0.0.1`, then verified the static onboarding UI includes the English/Japanese acknowledgement and original Switchmap link

## LLM involvement
Files modified with LLM assistance in this PR include: `README.md`, `docs/index.html`, `docs/onboarding.md`, and `docs/onboarding.ja.md`.

Human review required for correctness, tone, attribution, and licensing before merge.

## Compatibility and migration notes
- Documentation-only change.
- No Python API, CLI, or Pages workflow behavior changes.