### PR TITLE
Add CML SNMP validation fixtures and report UI shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # switchmappy generated onboarding demo output
 docs/assets/onboarding/demo/
+
+# Local live-lab validation output. Do not commit private CML/controller data.
+local_cml_snmpwalks/

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,6 +25,7 @@ Review required for correctness, security, and licensing.
 - [設定](configuration.ja.md)
 - [コマンド](commands.ja.md)
 - [テスト](testing.ja.md)
+- [Cisco CML SNMP 検証](snmp_cml_validation.ja.md)
 - [移行メモ](migration_notes.ja.md)
 - [SwitchMap 差分分析](switchmap_gap_analysis.ja.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Review required for correctness, security, and licensing.
 - [Configuration](configuration.md)
 - [Commands](commands.md)
 - [Testing](testing.md)
+- [Cisco CML SNMP Validation](snmp_cml_validation.md)
 - [Migration Notes](migration_notes.md)
 - [SwitchMap Gap Analysis](switchmap_gap_analysis.md)
 

--- a/docs/snmp_cml_validation.ja.md
+++ b/docs/snmp_cml_validation.ja.md
@@ -1,0 +1,126 @@
+<!--
+Copyright 2026 SwitchMappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Cisco CML SNMP 検証
+
+- English version: [snmp_cml_validation.md](snmp_cml_validation.md)
+
+このメモは、Cisco CML を使った SwitchMappy の SNMP switch collection 検証手順を記録します。主な対象は Q-BRIDGE と VLAN-indexed community の FDB 挙動です。
+
+## 範囲
+
+次の SNMP FDB ケースを検証します:
+
+- Q-BRIDGE VLAN FDB が返る場合に、port ごとの MAC と VLAN が取得できること。
+- Q-BRIDGE が空または未公開でも、`public@10` のような VLAN-indexed community で legacy BRIDGE-MIB FDB が返ること。
+- 診断が `Q-BRIDGE populated`、`Q-BRIDGE empty`、`FDB populated`、`VLAN-indexed community may be required` を区別すること。
+
+## CML トポロジ
+
+記録に残す名前とアドレスは documentation-only の値に置き換えてください:
+
+- Cisco IOSvL2、Catalyst 9000v、または同等の CML switch node
+- VLAN 10 と VLAN 20 など、複数の access VLAN
+- VLAN ごとに少なくとも 1 つの endpoint
+- LLDP や trunk evidence も同時に見る場合は router または 2 台目の switch
+
+private controller URL、実ラボの IP 割当、node inventory、生の production output はコミットしないでください。
+
+## 推奨 device 設定
+
+CML switch には同等の設定を入れます:
+
+```text
+snmp-server community public RO
+vlan 10
+ name USERS
+vlan 20
+ name SERVERS
+interface GigabitEthernet1/0/1
+ switchport mode access
+ switchport access vlan 10
+ no shutdown
+interface GigabitEthernet1/0/2
+ switchport mode access
+ switchport access vlan 20
+ no shutdown
+```
+
+SNMP 取得前に endpoint から通信を発生させ、FDB entry が学習されている状態にします。
+
+## Walk コマンド
+
+SwitchMappy が使う OID family だけを取得します。helper は git-ignored の `local_cml_snmpwalks/` に出力します:
+
+```bash
+python scripts/collect_cml_snmpwalk.py \
+  --target TARGET \
+  --community public \
+  --vlan 10 \
+  --vlan 20
+```
+
+手動で実行する場合の同等コマンド:
+
+```bash
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.31.1.1.1.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.31.1.1.1.18
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.2.2.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.1.4.1.2
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.7.1.2.2.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.7.1.4.3.1.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.47.1.1.1.1
+```
+
+VLAN-indexed community の検証:
+
+```bash
+snmpwalk -v2c -c public@10 TARGET 1.3.6.1.2.1.17.4.3.1
+snmpwalk -v2c -c public@20 TARGET 1.3.6.1.2.1.17.4.3.1
+```
+
+## Fixture 方針
+
+repository には合成 CML-style fixture だけを保存します:
+
+- `tests/fixtures/synthetic/cisco_cml_qbridge_snmpwalk.txt`
+- `tests/fixtures/synthetic/cisco_cml_vlan_indexed_community_snmpwalk.txt`
+
+CML 観測結果から fixture を更新する場合は、SNMP output の形だけを残します。hostname、IP address、serial number、MAC address は documentation-only または locally administered な合成値に置き換えてください。
+
+## 観測済み CML 挙動
+
+Catalyst 9000v 系の検証では、Q-BRIDGE table が空または未公開でも、VLAN-indexed legacy BRIDGE-MIB で endpoint MAC が返る場合があります。この場合、SwitchMappy は VLAN-indexed community 設定時に endpoint を相関し、`Q-BRIDGE empty`、`FDB populated`、`VLAN-indexed community may be required` の診断を出す必要があります。
+
+## 検証コマンド
+
+作業中の focused test:
+
+```bash
+python -m pytest tests/test_collectors.py -q
+```
+
+到達可能な CML lab target に対する local collection:
+
+```bash
+python scripts/collect_cml_snmpwalk.py --target TARGET --community public --vlan 10 --vlan 20
+```
+
+PR 前の標準検証:
+
+```bash
+python -m ruff check .
+python -m pytest -q
+python -m pre_commit run --all-files
+```

--- a/docs/snmp_cml_validation.md
+++ b/docs/snmp_cml_validation.md
@@ -1,0 +1,141 @@
+<!--
+Copyright 2026 SwitchMappy
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Cisco CML SNMP Validation
+
+- Japanese translation: [snmp_cml_validation.ja.md](snmp_cml_validation.ja.md)
+
+This note tracks repeatable Cisco CML validation for SNMP switch collection,
+especially Q-BRIDGE and VLAN-indexed community behavior.
+
+## Scope
+
+Validate that SwitchMappy handles these SNMP FDB cases:
+
+- Q-BRIDGE VLAN FDB rows are populated and produce per-port MAC and VLAN data.
+- Q-BRIDGE rows are absent while legacy BRIDGE-MIB FDB rows are visible through
+  a VLAN-indexed community such as `public@10`.
+- Diagnostics distinguish `Q-BRIDGE populated`, `Q-BRIDGE empty`, `FDB
+  populated`, and `VLAN-indexed community may be required`.
+
+## CML Topology
+
+Use documentation-only names and addresses in recorded notes:
+
+- one Cisco IOSvL2 or comparable CML switch node,
+- two access VLANs, for example VLAN 10 and VLAN 20,
+- one endpoint on each VLAN so the switch learns at least one MAC per VLAN,
+- optional trunk toward a router or second switch if LLDP and trunk evidence are
+  part of the same validation run.
+
+Do not commit private controller URLs, real lab addressing, node inventories, or
+raw production output.
+
+## Suggested Device Setup
+
+Use an equivalent configuration for the CML switch:
+
+```text
+snmp-server community public RO
+vlan 10
+ name USERS
+vlan 20
+ name SERVERS
+interface GigabitEthernet1/0/1
+ switchport mode access
+ switchport access vlan 10
+ no shutdown
+interface GigabitEthernet1/0/2
+ switchport mode access
+ switchport access vlan 20
+ no shutdown
+```
+
+Generate traffic from each endpoint before collecting SNMP data so FDB entries
+exist.
+
+## Walk Commands
+
+Collect only the OID families needed by SwitchMappy. Replace target and
+community values locally; do not commit private values. The helper writes to
+`local_cml_snmpwalks/`, which is git-ignored:
+
+```bash
+python scripts/collect_cml_snmpwalk.py \
+  --target TARGET \
+  --community public \
+  --vlan 10 \
+  --vlan 20
+```
+
+Equivalent manual commands:
+
+```bash
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.31.1.1.1.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.31.1.1.1.18
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.2.2.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.1.4.1.2
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.7.1.2.2.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.17.7.1.4.3.1.1
+snmpwalk -v2c -c public TARGET 1.3.6.1.2.1.47.1.1.1.1
+```
+
+For VLAN-indexed community validation:
+
+```bash
+snmpwalk -v2c -c public@10 TARGET 1.3.6.1.2.1.17.4.3.1
+snmpwalk -v2c -c public@20 TARGET 1.3.6.1.2.1.17.4.3.1
+```
+
+## Fixture Policy
+
+The repository stores synthetic CML-style fixtures under
+`tests/fixtures/synthetic/`:
+
+- `cisco_cml_qbridge_snmpwalk.txt`
+- `cisco_cml_vlan_indexed_community_snmpwalk.txt`
+
+When updating these fixtures from CML observations, preserve only the shape of
+the SNMP output. Replace hostnames, IP addresses, serial numbers, and MAC
+addresses with documentation-only or locally administered synthetic values.
+
+## Observed CML Behavior
+
+Catalyst 9000v-style validation may expose endpoint MACs through VLAN-indexed
+legacy BRIDGE-MIB while returning no Q-BRIDGE table rows. In that case,
+SwitchMappy should still correlate the endpoint when the configured community is
+VLAN-indexed, and it should emit diagnostics for `Q-BRIDGE empty`, `FDB
+populated`, and `VLAN-indexed community may be required`.
+
+## Validation Commands
+
+Run focused tests while iterating:
+
+```bash
+python -m pytest tests/test_collectors.py -q
+```
+
+Run the local CML collection helper against a reachable lab target:
+
+```bash
+python scripts/collect_cml_snmpwalk.py --target TARGET --community public --vlan 10 --vlan 20
+```
+
+Run standard validation before opening a PR:
+
+```bash
+python -m ruff check .
+python -m pytest -q
+python -m pre_commit run --all-files
+```

--- a/docs/switchmap_gap_analysis.ja.md
+++ b/docs/switchmap_gap_analysis.ja.md
@@ -38,7 +38,7 @@ Review required for correctness, security, and licensing.
 | Search UI | Implemented | `search/index.json` ベースの静的検索ページと FastAPI serve command。 | office/location workflow は専用viewが必要。 |
 | SSH switch collection | Implemented | Cisco系、Juniper、FortiSwitch、Arista向け command profile。 | platform variant のfixture拡張。 |
 | SNMP switch collection | Partial | IF-MIB、BRIDGE-MIB fallback、VLAN名、LLDP、sysDescr、sysUpTime、ENTITY-MIB inventory field、interface error、基本的な PoE status/power。 | 標準tableが不足する device-family 固有OIDを追加。 |
-| VLAN-aware SNMP FDB | Partial | デバイスが公開する場合は Q-BRIDGE FDB をparse。SNMP communityとして設定すれば VLAN-indexed community 収集も動作。診断では Q-BRIDGE empty/unavailable と legacy FDB fallback を区別。 | 追加の Q-BRIDGE 対応ターゲットで live-lab validation を行う。 |
+| VLAN-aware SNMP FDB | Partial | デバイスが公開する場合は Q-BRIDGE FDB をparse。SNMP communityとして設定すれば VLAN-indexed community 収集も動作。診断では Q-BRIDGE empty/unavailable と legacy FDB fallback を区別。Cisco CML 形式の SNMP walk fixture で populated Q-BRIDGE と VLAN-indexed legacy FDB behavior をカバー。 | 文書化した CML workflow を利用可能な lab target で検証し、観測した OID 形式が異なる場合は synthetic fixture を更新する。 |
 | LLDP/CDP neighbors | Implemented | SSH LLDP/CDP と SNMP LLDP neighbor を表示。 | vendor固有出力のcapability fixtureを追加。 |
 | Neighbor capabilities | Partial | CDP capability と SNMP LLDP capability bitmap を保持。 | capability field を省略または変化させる device fixture を追加する。 |
 | Trunk/uplink 表示 | Intentionally different | role は明示 `trunk_ports` または LLDP/CDP neighbor 根拠で決定。 | MAC数やendpoint数をrole根拠に使わない。 |
@@ -54,7 +54,7 @@ Review required for correctness, security, and licensing.
 ## 高優先度の残作業
 
 1. Office/location workflow PR: metadata import、search index field、location-oriented view を追加する。
-2. SNMP live-lab validation PR: 追加hardware/virtual targetで Q-BRIDGE と VLAN-indexed community behavior を検証する。
+2. SNMP live-lab validation PR: 文書化した Cisco CML workflow を利用可能な lab target で実行し、収集した OID 形式を synthetic fixture と比較して、必要なら test を更新する。
 3. Vendor OID PR: 標準MIBが不十分な device-family 向け inventory、PoE、error OID を追加する。
 4. Search/debug UX PR: operator が必要とする場合、Debug 以外の report surface に collector diagnostics を出す。
 5. Switchport fixture PR: 初期fixture以外の Juniper/Arista mode/native/allowed VLAN variant を拡張する。

--- a/docs/switchmap_gap_analysis.md
+++ b/docs/switchmap_gap_analysis.md
@@ -38,7 +38,7 @@ used by `SwitchMap.pl`, `ScanSwitch.pl`, `GetArp.pl`, `FindOffice.pl`,
 | Search UI | Implemented | Static search page backed by `search/index.json`; FastAPI serve command exists. | Office/location workflows need a dedicated view. |
 | SSH switch collection | Implemented | Cisco-like, Juniper, FortiSwitch, and Arista-oriented command profiles exist. | Expand command fixtures for more platform variants. |
 | SNMP switch collection | Partial | IF-MIB, BRIDGE-MIB fallback, VLAN names, LLDP, sysDescr, sysUpTime, ENTITY-MIB inventory fields, interface errors, and basic PoE status/power are supported. | Add device-family-specific OIDs where standard tables are absent or sparse. |
-| VLAN-aware SNMP FDB | Partial | Q-BRIDGE FDB is parsed when devices expose it; VLAN-indexed community collection works when configured as the SNMP community; diagnostics now distinguish Q-BRIDGE empty/unavailable from legacy FDB fallback. | Add live-lab validation on additional Q-BRIDGE-capable targets. |
+| VLAN-aware SNMP FDB | Partial | Q-BRIDGE FDB is parsed when devices expose it; VLAN-indexed community collection works when configured as the SNMP community; diagnostics now distinguish Q-BRIDGE empty/unavailable from legacy FDB fallback. Cisco CML-style SNMP walk fixtures cover populated Q-BRIDGE and VLAN-indexed legacy FDB behavior. | Validate the documented CML workflow against an available CML lab target and refresh synthetic fixtures if observed OID shape differs. |
 | LLDP/CDP neighbors | Implemented | SSH LLDP/CDP and SNMP LLDP neighbors are rendered. | Add more capability fixtures for vendor-specific outputs. |
 | Neighbor capabilities | Partial | CDP capabilities and SNMP LLDP capability bitmaps are retained when available. | Add fixtures for devices that omit or vary capability fields. |
 | Trunk/uplink display | Intentionally different | Roles use explicit `trunk_ports` or LLDP/CDP neighbor evidence. | Do not use MAC count or endpoint count as role evidence. |
@@ -54,7 +54,7 @@ used by `SwitchMap.pl`, `ScanSwitch.pl`, `GetArp.pl`, `FindOffice.pl`,
 ## Highest-Value Remaining Work
 
 1. Office/location workflow PR: add metadata import, search index fields, and a location-oriented view.
-2. SNMP live-lab validation PR: validate Q-BRIDGE and VLAN-indexed community behavior against additional hardware or virtual targets.
+2. SNMP live-lab validation PR: run the documented Cisco CML workflow against an available lab target, compare the collected OID shape with the synthetic fixtures, and refresh tests if needed.
 3. Vendor OID PR: add device-family-specific inventory, PoE, and error OIDs where standard MIBs are incomplete.
 4. Search/debug UX PR: expose collector diagnostics in more report surfaces beyond Debug if operators need them.
 5. Switchport fixture PR: expand Juniper and Arista variants beyond the initial mode/native/allowed VLAN evidence fixtures.

--- a/scripts/collect_cml_snmpwalk.py
+++ b/scripts/collect_cml_snmpwalk.py
@@ -1,0 +1,122 @@
+# Copyright 2026 SwitchMappy
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+OID_GROUPS = {
+    "if_name": "1.3.6.1.2.1.31.1.1.1.1",
+    "if_alias": "1.3.6.1.2.1.31.1.1.1.18",
+    "if_table": "1.3.6.1.2.1.2.2.1",
+    "bridge_port_ifindex": "1.3.6.1.2.1.17.1.4.1.2",
+    "qbridge_vlan_fdb": "1.3.6.1.2.1.17.7.1.2.2.1",
+    "qbridge_vlan_names": "1.3.6.1.2.1.17.7.1.4.3.1.1",
+    "entity_inventory": "1.3.6.1.2.1.47.1.1.1.1",
+}
+VLAN_INDEXED_OIDS = {
+    "legacy_fdb": "1.3.6.1.2.1.17.4.3.1",
+}
+
+
+def _run_snmpwalk(
+    target: str,
+    community: str,
+    oid: str,
+    timeout: int,
+    retries: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "snmpwalk",
+            "-v2c",
+            "-c",
+            community,
+            "-t",
+            str(timeout),
+            "-r",
+            str(retries),
+            target,
+            oid,
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _write_result(path: Path, result: subprocess.CompletedProcess[str]) -> None:
+    body = result.stdout
+    if result.stderr:
+        body += "\n# stderr\n" + result.stderr
+    path.write_text(body, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect Cisco CML SNMP walk excerpts for local validation.")
+    parser.add_argument("--target", required=True, help="CML switch management address or hostname.")
+    parser.add_argument("--community", required=True, help="SNMP v2c community for normal Q-BRIDGE collection.")
+    parser.add_argument(
+        "--vlan",
+        action="append",
+        default=[],
+        help="VLAN ID to collect with a VLAN-indexed community, for example --vlan 10.",
+    )
+    parser.add_argument("--timeout", type=int, default=2)
+    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument("--output-dir", type=Path, default=Path("local_cml_snmpwalks"))
+    args = parser.parse_args()
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = args.output_dir / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    failures: list[str] = []
+    for name, oid in OID_GROUPS.items():
+        result = _run_snmpwalk(args.target, args.community, oid, args.timeout, args.retries)
+        _write_result(run_dir / f"{name}.walk", result)
+        if result.returncode != 0:
+            failures.append(f"{name}: snmpwalk exited {result.returncode}")
+
+    for vlan in args.vlan:
+        community = f"{args.community}@{vlan}"
+        for name, oid in VLAN_INDEXED_OIDS.items():
+            result = _run_snmpwalk(args.target, community, oid, args.timeout, args.retries)
+            _write_result(run_dir / f"vlan_{vlan}_{name}.walk", result)
+            if result.returncode != 0:
+                failures.append(f"vlan {vlan} {name}: snmpwalk exited {result.returncode}")
+
+    (run_dir / "README.txt").write_text(
+        "\n".join(
+            [
+                "Local Cisco CML SNMP validation output.",
+                "Do not commit this directory.",
+                f"Target: {args.target}",
+                f"Normal community: {args.community}",
+                f"VLAN-indexed communities: {', '.join(args.vlan) if args.vlan else '(none)'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote SNMP walk output to {run_dir}")
+    if failures:
+        print("\n".join(failures))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/switchmap_py/render/build.py
+++ b/switchmap_py/render/build.py
@@ -377,6 +377,46 @@ def _build_debug_payload(
     }
 
 
+def _build_dashboard_diagnostics(
+    *,
+    switches: list[Switch],
+    failed_switch_reasons: dict[str, str],
+    artifacts_dir: Path | None,
+) -> list[dict[str, object]]:
+    artifacts = _build_artifact_summary(artifacts_dir)
+    snmp_fdb_diagnostics = _build_snmp_fdb_diagnostics(artifacts, failed_switch_reasons)
+    collector_diagnostics: list[dict[str, object]] = []
+    for switch in switches:
+        for diagnostic in switch.diagnostics:
+            if not isinstance(diagnostic, dict):
+                continue
+            collector_diagnostics.append(
+                {
+                    "switch": switch.name,
+                    "labels": diagnostic.get("label", ""),
+                    "detail": diagnostic.get("detail", ""),
+                }
+            )
+    diagnostics = sorted(
+        [*snmp_fdb_diagnostics, *collector_diagnostics],
+        key=lambda row: (str(row.get("switch") or ""), str(row.get("labels") or "")),
+    )
+    collapsed: list[dict[str, object]] = []
+    for diagnostic in diagnostics:
+        switch_name = str(diagnostic.get("switch") or "")
+        labels = str(diagnostic.get("labels") or "")
+        if any(
+            switch_name == str(existing.get("switch") or "")
+            and labels
+            and labels != str(existing.get("labels") or "")
+            and labels in str(existing.get("labels") or "")
+            for existing in diagnostics
+        ):
+            continue
+        collapsed.append(diagnostic)
+    return collapsed
+
+
 def _parser_profile_for_vendor(vendor: str) -> str:
     value = vendor.lower()
     if "juniper" in value:
@@ -758,12 +798,18 @@ def build_site(
         failed_switches=failed_switches,
     )
     vlan_summary = _build_vlan_summary(switches=switches, mac_entries_by_mac=mac_entries_by_mac)
+    dashboard_diagnostics = _build_dashboard_diagnostics(
+        switches=switches,
+        failed_switch_reasons=failed_switch_reasons,
+        artifacts_dir=artifacts_dir,
+    )
 
     index_html = index_template.render(
         switches=switches,
         failed_switches=failed_switches,
         failed_switch_reasons=failed_switch_reasons,
         report_summary=report_summary,
+        dashboard_diagnostics=dashboard_diagnostics[:5],
         build_date=build_date,
     )
     (output_dir / "index.html").write_text(index_html, encoding="utf-8")

--- a/switchmap_py/render/static/switchmap.css
+++ b/switchmap_py/render/static/switchmap.css
@@ -306,6 +306,29 @@ button:hover {
   padding: 0.85rem 1rem;
 }
 
+.preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 0.85rem;
+}
+
+.preset-row button {
+  background: #ffffff;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.preset-row button:hover {
+  background: #eef2f7;
+}
+
+.preset-row button[aria-pressed="true"] {
+  background: #1f2937;
+  border-color: #1f2937;
+  color: #ffffff;
+}
+
 .filter-row input[type="text"] {
   margin-bottom: 0;
 }
@@ -317,6 +340,21 @@ button:hover {
 .filter-row label {
   color: #475569;
   font-weight: 700;
+}
+
+.diagnostic-list {
+  display: grid;
+  gap: 0.55rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.diagnostic-list li {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .debug-grid {

--- a/switchmap_py/render/templates/index.html.j2
+++ b/switchmap_py/render/templates/index.html.j2
@@ -60,6 +60,21 @@ Review required for correctness, security, and licensing.
       </div>
     </div>
   </section>
+  {% if dashboard_diagnostics %}
+  <section class="panel panel-warning">
+    <h2>Diagnostics</h2>
+    <ul class="diagnostic-list">
+      {% for diagnostic in dashboard_diagnostics %}
+      <li>
+        <strong>{{ diagnostic.switch }}</strong>
+        <span class="badge badge-warning">{{ diagnostic.labels }}</span>
+        <span>{{ diagnostic.detail }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    <p><a href="/debug/index.html">Open full debug diagnostics</a></p>
+  </section>
+  {% endif %}
   <section class="panel">
     <h2>Switches</h2>
     <ul class="switch-list">

--- a/switchmap_py/render/templates/ports.html.j2
+++ b/switchmap_py/render/templates/ports.html.j2
@@ -25,6 +25,15 @@ Review required for correctness, security, and licensing.
     <p>Generated at {{ build_date.isoformat() }}</p>
   </header>
   {{ report_nav('ports') }}
+  <div class="preset-row" aria-label="Port filter presets">
+    <button type="button" data-preset="">All</button>
+    <button type="button" data-preset="unused">Unused</button>
+    <button type="button" data-preset="missing-description">Missing description</button>
+    <button type="button" data-preset="errors">Errors</button>
+    <button type="button" data-preset="poe">PoE active</button>
+    <button type="button" data-preset="neighbors">Network neighbors</button>
+    <button type="button" data-preset="link-up-no-mac">Link up no MAC</button>
+  </div>
   <div class="filter-row">
     <label for="statusFilter">Status:</label>
     <select id="statusFilter">
@@ -110,6 +119,9 @@ Review required for correctness, security, and licensing.
           data-status="{{ port.oper_status | lower }}"
           data-state="{{ state_label }}"
           data-neighbor="{{ port.neighbor_names | join(',') | lower }}"
+          data-mac-count="{{ port.macs | length }}"
+          data-missing-description="{% if port.needs_description %}true{% else %}false{% endif %}"
+          data-unused="{% if is_unused %}true{% else %}false{% endif %}"
           data-role="{{ port.role | lower }}"
           data-poe="{{ (port.poe_status or '') | lower }}"
           data-in-err="{{ port.input_errors if port.input_errors is not none else 0 }}"
@@ -184,6 +196,8 @@ Review required for correctness, security, and licensing.
   </section>
   {% endfor %}
   <script>
+    let activePreset = '';
+
     function applyFilters() {
       const status = document.getElementById('statusFilter').value;
       const poe = document.getElementById('poeFilter').value.toLowerCase().trim();
@@ -201,7 +215,17 @@ Review required for correctness, security, and licensing.
         const rowNeighbor = row.dataset.neighbor || '';
         const rowInErr = Number(row.dataset.inErr || '0');
         const rowOutErr = Number(row.dataset.outErr || '0');
+        const rowMacCount = Number(row.dataset.macCount || '0');
+        const matchesPreset =
+          !activePreset ||
+          (activePreset === 'unused' && row.dataset.unused === 'true') ||
+          (activePreset === 'missing-description' && row.dataset.missingDescription === 'true') ||
+          (activePreset === 'errors' && (rowInErr > 0 || rowOutErr > 0)) ||
+          (activePreset === 'poe' && rowPoe && rowPoe !== 'disabled' && rowPoe !== 'off') ||
+          (activePreset === 'neighbors' && row.dataset.role === 'network_neighbor') ||
+          (activePreset === 'link-up-no-mac' && row.dataset.state === 'link up, no MAC' && rowMacCount === 0);
         const match =
+          matchesPreset &&
           (!status || rowStatus === status) &&
           (!poe || rowPoe.includes(poe)) &&
           (!neighbor || rowNeighbor.includes(neighbor)) &&
@@ -213,9 +237,13 @@ Review required for correctness, security, and licensing.
       }
       document.getElementById('resultCount').textContent = `${visible} results`;
       document.getElementById('emptyState').hidden = visible > 0;
+      for (const button of document.querySelectorAll('[data-preset]')) {
+        button.setAttribute('aria-pressed', button.dataset.preset === activePreset ? 'true' : 'false');
+      }
     }
 
     function resetFilters() {
+      activePreset = '';
       document.getElementById('statusFilter').value = '';
       document.getElementById('poeFilter').value = '';
       document.getElementById('neighborFilter').value = '';
@@ -232,6 +260,12 @@ Review required for correctness, security, and licensing.
     document.getElementById('inErrFilter').addEventListener('input', applyFilters);
     document.getElementById('outErrFilter').addEventListener('input', applyFilters);
     document.getElementById('resetFilters').addEventListener('click', resetFilters);
+    for (const button of document.querySelectorAll('[data-preset]')) {
+      button.addEventListener('click', () => {
+        activePreset = button.dataset.preset || '';
+        applyFilters();
+      });
+    }
     applyFilters();
   </script>
 </body>

--- a/tests/fixtures/synthetic/cisco_cml_qbridge_snmpwalk.txt
+++ b/tests/fixtures/synthetic/cisco_cml_qbridge_snmpwalk.txt
@@ -1,0 +1,43 @@
+# Copyright 2026 SwitchMappy
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+#
+# Synthetic Cisco CML-style SNMP walk excerpt. Values use documentation-only
+# hostnames, addresses, and locally administered MACs; do not replace this with
+# raw private-lab output.
+
+.1.3.6.1.2.1.31.1.1.1.1.10101 = STRING: "Gi1/0/1"
+.1.3.6.1.2.1.31.1.1.1.1.10102 = STRING: "Gi1/0/2"
+.1.3.6.1.2.1.31.1.1.1.18.10101 = STRING: "CML user vlan"
+.1.3.6.1.2.1.31.1.1.1.18.10102 = STRING: "CML server vlan"
+.1.3.6.1.2.1.2.2.1.2.10101 = STRING: "GigabitEthernet1/0/1"
+.1.3.6.1.2.1.2.2.1.2.10102 = STRING: "GigabitEthernet1/0/2"
+.1.3.6.1.2.1.2.2.1.3.10101 = INTEGER: 6
+.1.3.6.1.2.1.2.2.1.3.10102 = INTEGER: 6
+.1.3.6.1.2.1.2.2.1.7.10101 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.7.10102 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.8.10101 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.8.10102 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.9.10101 = Timeticks: 1200
+.1.3.6.1.2.1.2.2.1.9.10102 = Timeticks: 2400
+.1.3.6.1.2.1.2.2.1.5.10101 = Gauge32: 1000000000
+.1.3.6.1.2.1.2.2.1.5.10102 = Gauge32: 1000000000
+.1.3.6.1.2.1.17.1.4.1.2.11 = INTEGER: 10101
+.1.3.6.1.2.1.17.1.4.1.2.12 = INTEGER: 10102
+.1.3.6.1.2.1.17.7.1.2.2.1.2.10.82.84.0.0.16.1 = INTEGER: 11
+.1.3.6.1.2.1.17.7.1.2.2.1.2.20.82.84.0.0.32.1 = INTEGER: 12
+.1.3.6.1.2.1.17.7.1.2.2.1.3.10.82.84.0.0.16.1 = INTEGER: 3
+.1.3.6.1.2.1.17.7.1.2.2.1.3.20.82.84.0.0.32.1 = INTEGER: 3
+.1.3.6.1.2.1.17.7.1.4.3.1.1.10 = STRING: "USERS"
+.1.3.6.1.2.1.17.7.1.4.3.1.1.20 = STRING: "SERVERS"
+.1.3.6.1.2.1.47.1.1.1.1.13.1 = STRING: "CML-IOSvL2"
+.1.3.6.1.2.1.47.1.1.1.1.11.1 = STRING: "DEMO-CML-0001"
+.1.3.6.1.2.1.47.1.1.1.1.10.1 = STRING: "15.2-CML"

--- a/tests/fixtures/synthetic/cisco_cml_vlan_indexed_community_snmpwalk.txt
+++ b/tests/fixtures/synthetic/cisco_cml_vlan_indexed_community_snmpwalk.txt
@@ -1,0 +1,30 @@
+# Copyright 2026 SwitchMappy
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+#
+# Synthetic Cisco CML-style SNMP walk excerpt for a VLAN-indexed community
+# fallback such as public@10, where legacy BRIDGE-MIB FDB rows are visible but
+# Q-BRIDGE rows are absent.
+
+.1.3.6.1.2.1.31.1.1.1.1.8 = STRING: "Gi1/0/1"
+.1.3.6.1.2.1.31.1.1.1.18.8 = STRING: "CML user vlan"
+.1.3.6.1.2.1.2.2.1.2.8 = STRING: "GigabitEthernet1/0/1"
+.1.3.6.1.2.1.2.2.1.3.8 = INTEGER: 6
+.1.3.6.1.2.1.2.2.1.7.8 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.8.8 = INTEGER: 1
+.1.3.6.1.2.1.2.2.1.9.8 = Timeticks: 1200
+.1.3.6.1.2.1.2.2.1.5.8 = Gauge32: 1000000000
+.1.3.6.1.2.1.17.1.4.1.2.1 = INTEGER: 8
+.1.3.6.1.2.1.17.4.3.1.2.82.84.0.0.65.16 = INTEGER: 1
+.1.3.6.1.2.1.17.4.3.1.3.82.84.0.0.65.16 = INTEGER: 3
+.1.3.6.1.2.1.47.1.1.1.1.13.1 = STRING: "CML-IOSvL2"
+.1.3.6.1.2.1.47.1.1.1.1.11.1 = STRING: "DEMO-CML-0002"
+.1.3.6.1.2.1.47.1.1.1.1.10.1 = STRING: "15.2-CML"

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -151,11 +151,16 @@ def test_index_page_renders_switchmappy_dashboard_summary(tmp_path):
     )
 
     index_html = (output_dir / "index.html").read_text(encoding="utf-8")
+    ports_html = (output_dir / "ports" / "index.html").read_text(encoding="utf-8")
     assert "<title>SwitchMappy</title>" in index_html
     assert "<h1>SwitchMappy</h1>" in index_html
     for label in ["switches", "ports", "active", "endpoints", "missing desc", "unused", "failed"]:
         assert label in index_html
     assert 'href="/debug/index.html">Debug</a>' in index_html
+    for preset in ["Unused", "Missing description", "Errors", "PoE active", "Network neighbors", "Link up no MAC"]:
+        assert preset in ports_html
+    assert 'data-preset="missing-description"' in ports_html
+    assert 'data-missing-description="true"' in ports_html
 
 
 def test_build_site_writes_history_snapshot(tmp_path):
@@ -322,6 +327,7 @@ def test_build_site_renders_debug_page_and_payload(tmp_path):
         artifacts_dir=artifacts_dir,
     )
 
+    index_html = (output_dir / "index.html").read_text(encoding="utf-8")
     debug_html = (output_dir / "debug" / "index.html").read_text(encoding="utf-8")
     search_index = json.loads((output_dir / "search" / "index.json").read_text(encoding="utf-8"))
     debug = search_index["debug"]
@@ -356,6 +362,9 @@ def test_build_site_renders_debug_page_and_payload(tmp_path):
     assert "VLAN-indexed community may be required" in debug["snmp_fdb_diagnostics"][1]["labels"]
     assert "SNMP FDB Diagnostics" in debug_html
     assert "VLAN-indexed community may be required" in debug_html
+    assert "Diagnostics" in index_html
+    assert "Open full debug diagnostics" in index_html
+    assert "Q-BRIDGE empty" in index_html
     assert "Collector Artifacts" in debug_html
     assert "Unsupported" in debug_html
     assert 'id="debugRole"' in debug_html

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -10,8 +10,12 @@
 # This file was created or modified with the assistance of an AI (Large Language Model).
 # Review required for correctness, security, and licensing.
 
+from pathlib import Path
+
 from switchmap_py.config import SwitchConfig
 from switchmap_py.snmp import collectors, mibs
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "synthetic"
 
 
 class StubSession:
@@ -20,6 +24,34 @@ class StubSession:
 
     def get_table(self, oid):
         return self._tables.get(oid, {})
+
+
+def _snmpwalk_fixture(name: str) -> dict[str, dict[str, str]]:
+    tables: dict[str, dict[str, str]] = {}
+    for raw_line in (FIXTURE_DIR / name).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        oid, value = _parse_snmpwalk_line(line)
+        for base_oid in vars(mibs).values():
+            if not isinstance(base_oid, str):
+                continue
+            if oid == base_oid or oid.startswith(f"{base_oid}."):
+                tables.setdefault(base_oid, {})[oid] = value
+                break
+    return tables
+
+
+def _parse_snmpwalk_line(line: str) -> tuple[str, str]:
+    oid_text, value_text = line.split("=", 1)
+    oid = oid_text.strip().removeprefix(".")
+    value = value_text.strip()
+    if ":" in value:
+        _value_type, value = value.split(":", 1)
+        value = value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    return oid, value
 
 
 def test_collect_switch_state_falls_back_to_descr_or_ifindex(monkeypatch):
@@ -216,3 +248,64 @@ def test_collect_switch_state_records_legacy_fdb_diagnostic_and_inventory(monkey
     assert state.ports[0].output_errors == 9
     assert state.ports[0].poe_status == "delivering"
     assert state.ports[0].poe_power_w == 15.4
+
+
+def test_collect_switch_state_covers_cisco_cml_qbridge_fixture(monkeypatch):
+    switch = SwitchConfig(
+        name="cml-iosvl2-1",
+        management_ip="192.0.2.10",
+        community="public",
+    )
+    tables = _snmpwalk_fixture("cisco_cml_qbridge_snmpwalk.txt")
+
+    monkeypatch.setattr(
+        collectors,
+        "build_session",
+        lambda *_args, **_kwargs: StubSession(tables),
+    )
+
+    state = collectors.collect_switch_state(switch, timeout=1, retries=0)
+    labels = [diagnostic["label"] for diagnostic in state.diagnostics]
+    ports_by_name = {port.name: port for port in state.ports}
+
+    assert labels == ["Q-BRIDGE populated"]
+    assert ports_by_name["Gi1/0/1"].vlan == "10"
+    assert ports_by_name["Gi1/0/1"].macs == ["52:54:00:00:10:01"]
+    assert ports_by_name["Gi1/0/2"].vlan == "20"
+    assert ports_by_name["Gi1/0/2"].macs == ["52:54:00:00:20:01"]
+    assert [(vlan.vlan_id, vlan.name, vlan.ports, vlan.source) for vlan in state.vlans] == [
+        ("10", "USERS", ["Gi1/0/1"], "named"),
+        ("20", "SERVERS", ["Gi1/0/2"], "named"),
+    ]
+    assert state.platform == "CML-IOSvL2"
+    assert state.serial_number == "DEMO-CML-0001"
+    assert state.os_version == "15.2-CML"
+
+
+def test_collect_switch_state_covers_cisco_cml_vlan_indexed_community_fixture(monkeypatch):
+    switch = SwitchConfig(
+        name="cml-iosvl2-1-vlan10",
+        management_ip="192.0.2.10",
+        community="public@10",
+    )
+    tables = _snmpwalk_fixture("cisco_cml_vlan_indexed_community_snmpwalk.txt")
+
+    monkeypatch.setattr(
+        collectors,
+        "build_session",
+        lambda *_args, **_kwargs: StubSession(tables),
+    )
+
+    state = collectors.collect_switch_state(switch, timeout=1, retries=0)
+    labels = [diagnostic["label"] for diagnostic in state.diagnostics]
+
+    assert labels == [
+        "Q-BRIDGE empty",
+        "FDB populated",
+        "VLAN-indexed community may be required",
+    ]
+    assert state.ports[0].name == "Gi1/0/1"
+    assert state.ports[0].macs == ["52:54:00:00:41:10"]
+    assert state.ports[0].vlan is None
+    assert state.vlans == []
+    assert state.platform == "CML-IOSvL2"


### PR DESCRIPTION
## Summary

- Add synthetic Cisco CML-style SNMP walk fixtures for Q-BRIDGE and VLAN-indexed legacy BRIDGE-MIB FDB behavior.
- Add a local helper for collecting focused SNMP walk excerpts into ignored local output.
- Document Cisco CML SNMP validation in English and Japanese.
- Add Dashboard diagnostics and Ports page preset filters for common operator workflows.

## Rationale

This improves repeatable SNMP FDB validation while keeping private lab output out of the repository. The UI changes surface collection/FDB diagnostics earlier and make common port investigations faster.

## Tests and validation

- `python -m pytest tests/test_build_site.py tests/test_collectors.py tests/test_synthetic_fixture_policy.py -q` — passed
- `python scripts/check_docs_links.py` — passed
- `python -m ruff check .` — passed
- `python -m pytest -q` — passed, 162 tests
- `python -m pre_commit run --all-files` — passed
- Browser smoke check against generated demo output for Dashboard diagnostics and Ports presets — passed

## Docs

- Added `docs/snmp_cml_validation.md` and `docs/snmp_cml_validation.ja.md`.
- Updated docs indexes and SwitchMap gap analysis pages.

## Backward compatibility

No config format changes. New UI controls are additive. The SNMP collection helper writes to ignored local output by default.

## LLM involvement

Files created/modified with LLM assistance:

- `.gitignore`
- `docs/README.md`
- `docs/README.ja.md`
- `docs/snmp_cml_validation.md`
- `docs/snmp_cml_validation.ja.md`
- `docs/switchmap_gap_analysis.md`
- `docs/switchmap_gap_analysis.ja.md`
- `scripts/collect_cml_snmpwalk.py`
- `switchmap_py/render/build.py`
- `switchmap_py/render/static/switchmap.css`
- `switchmap_py/render/templates/index.html.j2`
- `switchmap_py/render/templates/ports.html.j2`
- `tests/test_build_site.py`
- `tests/test_collectors.py`
- `tests/fixtures/synthetic/cisco_cml_qbridge_snmpwalk.txt`
- `tests/fixtures/synthetic/cisco_cml_vlan_indexed_community_snmpwalk.txt`

Human review: pending maintainer review.

## Checklist

- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: N/A, all checks passed (command: `python -m ruff check .`)
- [x] Tests pass locally (command: `python -m pytest -q`)
- [x] Static analysis/type checks pass (command: `python -m ruff check .`)
- [x] Formatting applied (command: `python -m pre_commit run --all-files`)
- [x] Pre-commit hooks pass
- [ ] CI build passes
- [ ] No merge conflicts with base branch
- [ ] Changelog/versioning updated (if applicable)
- [x] Documentation updated (README, docs/, API docs)
- [x] Examples/quick-start updated (if applicable)
- [x] Commit messages follow repository conventions
- [x] PR description includes: summary, rationale, tests, docs, migration notes
- [x] PR description explicitly lists LLM-modified files and human review notes